### PR TITLE
TASK-001: Contratos TypeScript

### DIFF
--- a/__typetests__/customer-schema.type-test.ts
+++ b/__typetests__/customer-schema.type-test.ts
@@ -1,0 +1,79 @@
+import type { SchemaDefinition, InferSelectModel, InferInsertModel } from "../src/index";
+
+type Expect<T extends true> = T;
+
+/**
+ * Igualdade estrutural via checagem mútua de `extends` (tuple-wrapped pra
+ * evitar distribuição sobre unions). Usado em vez do truque clássico de
+ * variância por função porque este falha (falso negativo) ao comparar um
+ * mapped type computado com zero chaves contra um object literal plano —
+ * mesmo quando ambos são estruturalmente equivalentes nos dois sentidos.
+ */
+type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+interface Customer {
+  id: string;
+  name: string;
+  phone: string;
+}
+
+const CustomerSchema = {
+  name: "customers",
+  version: 1,
+  primaryKey: "id",
+
+  columns: {
+    id: { type: "text" },
+    name: { type: "text" },
+    phone: { type: "text" },
+  },
+
+  sync: {
+    enabled: true,
+    direction: "bidirectional",
+    strategy: "operations",
+    conflict: "lastWriteWins",
+    transport: "rest",
+
+    endpoint: {
+      method: "POST",
+      path: "/sync/customers",
+    },
+
+    background: {
+      enabled: true,
+      minimumInterval: 15,
+      requiresNetwork: true,
+    },
+
+    pagination: {
+      pageSize: 200,
+      maxPagesPerSession: 20,
+    },
+
+    request: {
+      body: {
+        cursor: { $ref: "cursor" },
+        operations: { $ref: "operations" },
+        pageSize: { $ref: "pageSize" },
+      },
+    },
+
+    response: {
+      cursor: "$.cursor",
+      operations: "$.operations",
+      hasMore: "$.hasMore",
+    },
+  },
+} satisfies SchemaDefinition<Customer>;
+
+// Nenhuma coluna é nullable ou tem default — select e insert devem ter todas
+// as três colunas obrigatórias, sem `| null`.
+export type _SelectOk = Expect<Equal<InferSelectModel<typeof CustomerSchema>, { id: string; name: string; phone: string }>>;
+
+export type _InsertOk = Expect<Equal<InferInsertModel<typeof CustomerSchema>, { id: string; name: string; phone: string }>>;
+
+// Guarda contra o helper `Equal` sempre resolver `true` — este caso deve
+// falhar a comparação (shape errada) e por isso é esperado dar erro de tipo.
+// @ts-expect-error — shape errada de propósito, ver comentário acima
+export type _Negative = Expect<Equal<InferSelectModel<typeof CustomerSchema>, { id: number }>>;

--- a/docs/tasks/001-ts-contracts.md
+++ b/docs/tasks/001-ts-contracts.md
@@ -1,6 +1,6 @@
 # TASK-001 — Contratos TypeScript
 
-**Status:** ⬜ Não iniciado
+**Status:** ✅ Finalizado
 **Prioridade:** P0 (bloqueante)
 **Área:** TS
 **Depende de:** Nenhuma — pode começar imediatamente
@@ -31,11 +31,11 @@ Onde `mvp-scope.md` já restringiu uma union pra 1 membro fixo no MVP (ex: `Sync
 
 ## Critérios de aceite
 
-- [ ] Todo type/interface listado acima existe em `.ts` real dentro de `src/`, organizado em arquivos por domínio (ex: `sync-contracts.ts`, `query-contracts.ts`, `schema-contracts.ts`) — não um único arquivo gigante, e sem virar barrel file (convenção de `.agents/skills/build-nitro-modules/references/spec-hybrid-object.md`).
-- [ ] `npm run typecheck` passa sem erro.
-- [ ] Nenhum `any` implícito ou explícito nos types públicos.
-- [ ] Os comentários `// MVP:` de `architecture.md` foram preservados como JSDoc nos arquivos `.ts` (documentação, não só no doc markdown).
-- [ ] `InferSelectModel`/`InferInsertModel` testados manualmente contra o `CustomerSchema` de exemplo de `docs/project.md` — o tipo inferido bate com o esperado (checar via `// @ts-expect-error` ou type-level test).
+- [x] Todo type/interface listado acima existe em `.ts` real dentro de `src/`, organizado em arquivos por domínio (ex: `sync-contracts.ts`, `query-contracts.ts`, `schema-contracts.ts`) — não um único arquivo gigante, e sem virar barrel file (convenção de `.agents/skills/build-nitro-modules/references/spec-hybrid-object.md`).
+- [x] `npm run typecheck` passa sem erro.
+- [x] Nenhum `any` implícito ou explícito nos types públicos.
+- [x] Os comentários `// MVP:` de `architecture.md` foram preservados como JSDoc nos arquivos `.ts` (documentação, não só no doc markdown).
+- [x] `InferSelectModel`/`InferInsertModel` testados manualmente contra o `CustomerSchema` de exemplo de `docs/project.md` — o tipo inferido bate com o esperado (checar via `// @ts-expect-error` ou type-level test).
 
 ## Fora de escopo
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -6,7 +6,7 @@ Quebra do MVP (ver [`../mvp-scope.md`](../mvp-scope.md)) em tarefas independente
 
 | # | Tarefa | Status | Prioridade | Área | Depende de | Skills |
 |---|---|---|---|---|---|---|
-| [001](./001-ts-contracts.md) | Contratos TypeScript | ⬜ | P0 | TS | — | `api-design` |
+| [001](./001-ts-contracts.md) | Contratos TypeScript | ✅ | P0 | TS | — | `api-design` |
 | [002](./002-nitro-hybrid-spec.md) | Nitro HybridObject Spec | ⬜ | P0 | TS | 001 | `build-nitro-modules`, `api-design` |
 | [003](./003-test-harness-bootstrap.md) | Bootstrap de test harness | ⬜ | P1 | Tooling | — | — |
 | [004](./004-sqlite-core.md) | SQLite Core & Connection Management | ⬜ | P0 | C++ (core) | 002 | `cpp` |

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:contracts": "tsc -p tsconfig.typetest.json",
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint-ci": "eslint \"**/*.{js,ts,tsx}\" -f @jamesacarr/github-actions --max-warnings 0",

--- a/src/contracts/json-path.ts
+++ b/src/contracts/json-path.ts
@@ -1,0 +1,6 @@
+/**
+ * Caminho JSON (estilo JSONPath, ex: `$.cursor`) usado pra extrair valores
+ * de uma resposta HTTP declarativa — ver {@link ResponseDefinition} e
+ * {@link CredentialsDefinition}.
+ */
+export type JsonPath = string;

--- a/src/contracts/query/compiled-query.ts
+++ b/src/contracts/query/compiled-query.ts
@@ -1,0 +1,5 @@
+/** SQL compilado a partir de um query builder, pronto pra execução nativa. */
+export interface CompiledQuery {
+  sql: string;
+  params: unknown[];
+}

--- a/src/contracts/query/condition.ts
+++ b/src/contracts/query/condition.ts
@@ -1,0 +1,5 @@
+/**
+ * Condição de `where`, construída pelas funções de {@link ./operators}.
+ * Opaca pro usuário — não deve ser inspecionada ou construída manualmente.
+ */
+export type Condition = unknown;

--- a/src/contracts/query/infer-model.ts
+++ b/src/contracts/query/infer-model.ts
@@ -1,5 +1,14 @@
-import type { ColumnTsType } from "../schema/column-definition";
+import type { ColumnDefinition, ColumnTsType } from "../schema/column-definition";
 import type { AnySchema } from "../schema/any-schema";
+
+/**
+ * Se uma coluna declara `default`. Checa a PRESENÇA da chave (`keyof`), não
+ * se o valor faz `extends undefined` — indexar `["default"]` numa coluna
+ * literal que nunca declarou essa chave opcional resolve pra `unknown`
+ * (não pra `undefined`) nesse contexto de mapped type genérico, então checar
+ * o valor faria toda coluna sem `default` virar opcional por engano.
+ */
+type ColumnHasDefault<C extends ColumnDefinition> = "default" extends keyof C ? true : false;
 
 /** Infere o modelo de leitura (linha retornada por `select`) de um schema. */
 export type InferSelectModel<TSchema extends AnySchema> = {
@@ -10,13 +19,13 @@ export type InferSelectModel<TSchema extends AnySchema> = {
 export type InferInsertModel<TSchema extends AnySchema> = {
   [K in keyof TSchema["columns"] as TSchema["columns"][K]["nullable"] extends true
     ? K
-    : TSchema["columns"][K]["default"] extends undefined
-      ? never
-      : K]?: ColumnTsType<TSchema["columns"][K]["type"]>;
+    : ColumnHasDefault<TSchema["columns"][K]> extends true
+      ? K
+      : never]?: ColumnTsType<TSchema["columns"][K]["type"]>;
 } & {
   [K in keyof TSchema["columns"] as TSchema["columns"][K]["nullable"] extends true
     ? never
-    : TSchema["columns"][K]["default"] extends undefined
-      ? K
-      : never]: ColumnTsType<TSchema["columns"][K]["type"]>;
+    : ColumnHasDefault<TSchema["columns"][K]> extends true
+      ? never
+      : K]: ColumnTsType<TSchema["columns"][K]["type"]>;
 };

--- a/src/contracts/query/infer-model.ts
+++ b/src/contracts/query/infer-model.ts
@@ -1,0 +1,22 @@
+import type { ColumnTsType } from "../schema/column-definition";
+import type { AnySchema } from "../schema/any-schema";
+
+/** Infere o modelo de leitura (linha retornada por `select`) de um schema. */
+export type InferSelectModel<TSchema extends AnySchema> = {
+  [K in keyof TSchema["columns"]]: ColumnTsType<TSchema["columns"][K]["type"]> | (TSchema["columns"][K]["nullable"] extends true ? null : never);
+};
+
+/** Infere o modelo de escrita (linha aceita por `insert`) de um schema. */
+export type InferInsertModel<TSchema extends AnySchema> = {
+  [K in keyof TSchema["columns"] as TSchema["columns"][K]["nullable"] extends true
+    ? K
+    : TSchema["columns"][K]["default"] extends undefined
+      ? never
+      : K]?: ColumnTsType<TSchema["columns"][K]["type"]>;
+} & {
+  [K in keyof TSchema["columns"] as TSchema["columns"][K]["nullable"] extends true
+    ? never
+    : TSchema["columns"][K]["default"] extends undefined
+      ? K
+      : never]: ColumnTsType<TSchema["columns"][K]["type"]>;
+};

--- a/src/contracts/query/operators.ts
+++ b/src/contracts/query/operators.ts
@@ -1,0 +1,22 @@
+import type { Condition } from "./condition";
+
+/**
+ * Operadores de condição usados em `.where(...)`. Assinatura apenas — a
+ * implementação é responsabilidade da TASK-013 (Query Builder).
+ *
+ * Fora do MVP: `ilike`, `between`, `arrayContains`, subqueries.
+ */
+export declare function eq<T>(column: T, value: T): Condition;
+export declare function ne<T>(column: T, value: T): Condition;
+export declare function gt<T>(column: T, value: T): Condition;
+export declare function gte<T>(column: T, value: T): Condition;
+export declare function lt<T>(column: T, value: T): Condition;
+export declare function lte<T>(column: T, value: T): Condition;
+export declare function like(column: string, pattern: string): Condition;
+export declare function inArray<T>(column: T, values: T[]): Condition;
+export declare function isNull(column: unknown): Condition;
+export declare function isNotNull(column: unknown): Condition;
+
+export declare function and(...conditions: Condition[]): Condition;
+export declare function or(...conditions: Condition[]): Condition;
+export declare function not(condition: Condition): Condition;

--- a/src/contracts/query/query-client.ts
+++ b/src/contracts/query/query-client.ts
@@ -1,0 +1,56 @@
+import type { AnySchema } from "../schema/any-schema";
+import type { Condition } from "./condition";
+import type { InferSelectModel, InferInsertModel } from "./infer-model";
+
+/** Cliente de query, obtido do database configurado. */
+export interface QueryClient {
+  select<TSchema extends AnySchema>(schema: TSchema): SelectQueryBuilder<TSchema>;
+
+  insert<TSchema extends AnySchema>(schema: TSchema): InsertQueryBuilder<TSchema>;
+
+  update<TSchema extends AnySchema>(schema: TSchema): UpdateQueryBuilder<TSchema>;
+
+  delete<TSchema extends AnySchema>(schema: TSchema): DeleteQueryBuilder<TSchema>;
+
+  /**
+   * BEGIN/COMMIT/ROLLBACK nativo. Se `fn` lançar, faz ROLLBACK.
+   * Todo write dentro de `tx` ainda dispara as triggers normalmente
+   * (a fila de sync só é populada no COMMIT, não em cada write isolado).
+   */
+  transaction<T>(fn: (tx: QueryClient) => Promise<T>): Promise<T>;
+
+  /**
+   * Escape hatch. Sem type-safety, sem inferência — mas como a trigger
+   * é a nível de tabela SQLite, raw SQL ainda fica rastreado pela
+   * sync_queue normalmente.
+   */
+  execute(sql: string, params?: unknown[]): Promise<unknown[]>;
+}
+
+/** Builder de `select`, obtido via `QueryClient.select()`. */
+export interface SelectQueryBuilder<TSchema extends AnySchema> {
+  where(condition: Condition): this;
+  orderBy(column: keyof InferSelectModel<TSchema>, direction?: "asc" | "desc"): this;
+  limit(n: number): this;
+  offset(n: number): this;
+  execute(): Promise<InferSelectModel<TSchema>[]>;
+}
+
+/** Builder de `insert`, obtido via `QueryClient.insert()`. */
+export interface InsertQueryBuilder<TSchema extends AnySchema> {
+  values(row: InferInsertModel<TSchema>): this;
+  execute(): Promise<void>;
+}
+
+/** Builder de `update`, obtido via `QueryClient.update()`. */
+export interface UpdateQueryBuilder<TSchema extends AnySchema> {
+  set(patch: Partial<InferInsertModel<TSchema>>): this;
+  where(condition: Condition): this;
+  execute(): Promise<void>;
+}
+
+/** Builder de `delete`, obtido via `QueryClient.delete()`. */
+export interface DeleteQueryBuilder<TSchema extends AnySchema> {
+  where(condition: Condition): this;
+  execute(): Promise<void>;
+}

--- a/src/contracts/query/query-client.ts
+++ b/src/contracts/query/query-client.ts
@@ -50,7 +50,7 @@ export interface UpdateQueryBuilder<TSchema extends AnySchema> {
 }
 
 /** Builder de `delete`, obtido via `QueryClient.delete()`. */
-export interface DeleteQueryBuilder<TSchema extends AnySchema> {
+export interface DeleteQueryBuilder<_TSchema extends AnySchema> {
   where(condition: Condition): this;
   execute(): Promise<void>;
 }

--- a/src/contracts/schema/any-schema.ts
+++ b/src/contracts/schema/any-schema.ts
@@ -1,0 +1,11 @@
+import type { SchemaDefinition } from "./schema-definition";
+
+/**
+ * Constraint genérica que aceita qualquer {@link SchemaDefinition}.
+ *
+ * O `any` aqui é intencional e necessário (mirrors Drizzle): `unknown` quebra
+ * `keyof TEntity` em `SchemaDefinition.primaryKey` ao ser usado como bound de
+ * generic (`TSchema extends SchemaDefinition<unknown>` não tipa `keyof
+ * TEntity` de forma útil). Esta é a única ocorrência de `any` do pacote.
+ */
+export type AnySchema = SchemaDefinition<any>;

--- a/src/contracts/schema/column-definition.ts
+++ b/src/contracts/schema/column-definition.ts
@@ -1,0 +1,41 @@
+/** Definição de uma coluna de um {@link SchemaDefinition}. */
+export interface ColumnDefinition {
+  /** Tipo SQLite da coluna. */
+  type: "text" | "integer" | "real" | "boolean" | "blob" | "datetime";
+
+  /** Se `true`, a coluna aceita `NULL`. */
+  nullable?: boolean;
+
+  /** Se `true`, a coluna tem constraint `UNIQUE`. */
+  unique?: boolean;
+
+  /** Valor default da coluna. */
+  default?: unknown;
+}
+
+/**
+ * Mapeia o `type` declarativo de um {@link ColumnDefinition} pro tipo TS
+ * correspondente:
+ *
+ * | `ColumnDefinition.type` | TS |
+ * |---|---|
+ * | `text` | `string` |
+ * | `integer` | `number` |
+ * | `real` | `number` |
+ * | `boolean` | `boolean` (SQLite guarda 0/1, coerção fica no native) |
+ * | `blob` | `Uint8Array` |
+ * | `datetime` | `number` (epoch millis — mesma convenção de `SyncOperation.updatedAt`) |
+ */
+export type ColumnTsType<T extends ColumnDefinition["type"]> = T extends "text"
+  ? string
+  : T extends "integer"
+    ? number
+    : T extends "real"
+      ? number
+      : T extends "boolean"
+        ? boolean
+        : T extends "blob"
+          ? Uint8Array
+          : T extends "datetime"
+            ? number
+            : never;

--- a/src/contracts/schema/index-definition.ts
+++ b/src/contracts/schema/index-definition.ts
@@ -1,0 +1,11 @@
+/** Definição de um índice de um {@link SchemaDefinition}. */
+export interface IndexDefinition {
+  /** Nome único do índice. */
+  name: string;
+
+  /** Colunas cobertas pelo índice, na ordem declarada. */
+  columns: string[];
+
+  /** Se `true`, o índice tem constraint `UNIQUE`. */
+  unique?: boolean;
+}

--- a/src/contracts/schema/schema-definition.ts
+++ b/src/contracts/schema/schema-definition.ts
@@ -1,0 +1,28 @@
+import type { ColumnDefinition } from "./column-definition";
+import type { IndexDefinition } from "./index-definition";
+import type { SyncDefinition } from "../sync/sync-definition";
+
+/** Definição declarativa de um schema (tabela) local. */
+export interface SchemaDefinition<TEntity> {
+  /**
+   * Nome único do schema.
+   *
+   * Ex: `customers`
+   */
+  name: string;
+
+  /** Versão utilizada para migrações. */
+  version: number;
+
+  /** Primary key. */
+  primaryKey: keyof TEntity;
+
+  /** Colunas. */
+  columns: Record<string, ColumnDefinition>;
+
+  /** Índices. */
+  indexes?: IndexDefinition[];
+
+  /** Contrato de sincronização. */
+  sync?: SyncDefinition<TEntity>;
+}

--- a/src/contracts/sync/auth-provider.ts
+++ b/src/contracts/sync/auth-provider.ts
@@ -1,0 +1,10 @@
+/**
+ * Provider de credenciais global (`Database.configure().credentials.provider`).
+ *
+ * Não confundir com {@link AuthStrategy}, que é por-endpoint (ver
+ * {@link AuthenticationDefinition}) e está fora do MVP — MVP usa só
+ * credenciais globais via `AuthProvider`.
+ *
+ * MVP: só `"oauth2"` é implementada.
+ */
+export type AuthProvider = "oauth2"; // MVP: única implementada

--- a/src/contracts/sync/auth-strategy.ts
+++ b/src/contracts/sync/auth-strategy.ts
@@ -1,0 +1,6 @@
+/**
+ * Estratégia de autenticação por-endpoint de um {@link AuthenticationDefinition}.
+ *
+ * Não confundir com {@link AuthProvider}, que é a credencial global do app.
+ */
+export type AuthStrategy = "none" | "bearer" | "basic" | "custom";

--- a/src/contracts/sync/authentication-definition.ts
+++ b/src/contracts/sync/authentication-definition.ts
@@ -1,0 +1,16 @@
+import type { AuthStrategy } from "./auth-strategy";
+
+/**
+ * Autenticação por-endpoint.
+ *
+ * Fora do MVP. Auth no MVP é global e única (ver {@link CredentialsDefinition}).
+ * Este tipo fica reservado pra quando houver caso real de múltiplas
+ * APIs/credenciais distintas por schema.
+ */
+export interface AuthenticationDefinition {
+  strategy: AuthStrategy;
+
+  tokenKey?: string;
+
+  headerName?: string;
+}

--- a/src/contracts/sync/background-definition.ts
+++ b/src/contracts/sync/background-definition.ts
@@ -1,0 +1,10 @@
+/** Configuração de sync em background de um {@link SyncDefinition}. */
+export interface BackgroundDefinition {
+  enabled: boolean;
+
+  minimumInterval: number;
+
+  requiresNetwork?: boolean;
+
+  requiresCharging?: boolean;
+}

--- a/src/contracts/sync/compression-definition.ts
+++ b/src/contracts/sync/compression-definition.ts
@@ -1,0 +1,6 @@
+/** Fora do MVP. Não referenciado em nenhum `SyncDefinition` ainda. */
+export interface CompressionDefinition {
+  enabled: boolean;
+
+  algorithm: "gzip" | "brotli";
+}

--- a/src/contracts/sync/conflict-strategy.ts
+++ b/src/contracts/sync/conflict-strategy.ts
@@ -1,0 +1,10 @@
+/**
+ * Estratégia de resolução de conflitos de um {@link SyncDefinition}.
+ *
+ * MVP: só `"lastWriteWins"` é implementada.
+ */
+export type ConflictStrategy =
+  | "lastWriteWins" // MVP: única implementada
+  | "serverWins"
+  | "clientWins"
+  | "manual";

--- a/src/contracts/sync/credentials-definition.ts
+++ b/src/contracts/sync/credentials-definition.ts
@@ -1,0 +1,28 @@
+import type { AuthProvider } from "./auth-provider";
+import type { JsonPath } from "../json-path";
+
+/** Credencial única e global do app (ver {@link DatabaseConfigDefinition}). */
+export interface CredentialsDefinition {
+  provider: AuthProvider;
+
+  /** Onde o access token viaja nas requests de sync. */
+  accessToken: {
+    /** @default "Authorization" */
+    headerName?: string;
+  };
+
+  /**
+   * Contrato de refresh. Disparado pelo Native Sync Engine quando um
+   * request de sync recebe 401 — JavaScript nunca participa.
+   */
+  refresh: {
+    endpoint: string;
+    request: {
+      refreshToken: { $ref: "refreshToken" };
+    };
+    response: {
+      accessToken: JsonPath;
+      refreshToken: JsonPath;
+    };
+  };
+}

--- a/src/contracts/sync/database-config-definition.ts
+++ b/src/contracts/sync/database-config-definition.ts
@@ -1,0 +1,19 @@
+import type { CredentialsDefinition } from "./credentials-definition";
+
+/**
+ * Contrato do `Database.configure()`. Fonte de credenciais única do MVP.
+ */
+export interface DatabaseConfigDefinition {
+  baseUrl: string;
+
+  network?: {
+    timeout: number;
+  };
+
+  /**
+   * Credencial única e global do app. Sem override por schema no MVP.
+   * Escala futura: vira `Record<string, CredentialsDefinition>` chaveado
+   * por provider/API, sem quebrar quem só usa uma credencial.
+   */
+  credentials: CredentialsDefinition;
+}

--- a/src/contracts/sync/encryption-definition.ts
+++ b/src/contracts/sync/encryption-definition.ts
@@ -1,0 +1,6 @@
+/** Fora do MVP. Não referenciado em nenhum `SyncDefinition` ainda. */
+export interface EncryptionDefinition {
+  enabled: boolean;
+
+  algorithm: "aes256";
+}

--- a/src/contracts/sync/endpoint-definition.ts
+++ b/src/contracts/sync/endpoint-definition.ts
@@ -1,0 +1,13 @@
+import type { HttpMethod } from "./http-method";
+import type { AuthenticationDefinition } from "./authentication-definition";
+
+/** Endpoint HTTP de um {@link SyncDefinition}. */
+export interface EndpointDefinition {
+  method: HttpMethod;
+
+  path: string;
+
+  headers?: Record<string, string>;
+
+  authentication?: AuthenticationDefinition;
+}

--- a/src/contracts/sync/http-method.ts
+++ b/src/contracts/sync/http-method.ts
@@ -1,0 +1,2 @@
+/** Método HTTP usado por um {@link EndpointDefinition}. */
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";

--- a/src/contracts/sync/native-sync-result.ts
+++ b/src/contracts/sync/native-sync-result.ts
@@ -1,0 +1,14 @@
+/** Resultado de uma execução de sync retornado pelo Native Sync Engine. */
+export interface NativeSyncResult {
+  cursor?: string;
+
+  operationsApplied: number;
+
+  inserted: number;
+
+  updated: number;
+
+  deleted: number;
+
+  duration: number;
+}

--- a/src/contracts/sync/pagination-definition.ts
+++ b/src/contracts/sync/pagination-definition.ts
@@ -1,0 +1,19 @@
+/** Paginação de um {@link SyncDefinition}. */
+export interface PaginationDefinition {
+  /**
+   * Itens por página. Usado tanto no `$ref: "pageSize"` da request
+   * (pull) quanto pra limitar quantas linhas da sync_queue entram
+   * num request de push.
+   */
+  pageSize: number;
+
+  /**
+   * Teto de páginas por sessão de sync (mesma janela de conectividade).
+   * Evita loop longo demais drenando bateria numa única wake do
+   * scheduler. Ao atingir o teto com `hasMore` ainda `true`, o engine para
+   * e retoma no próximo wake — cursor já avançou até onde deu.
+   *
+   * @default 20
+   */
+  maxPagesPerSession?: number;
+}

--- a/src/contracts/sync/request-definition.ts
+++ b/src/contracts/sync/request-definition.ts
@@ -1,6 +1,6 @@
 import type { RequestExpression } from "./request-expression";
 
 /** Body declarativo de uma request de sync. */
-export interface RequestDefinition<TEntity> {
+export interface RequestDefinition<_TEntity> {
   body: Record<string, RequestExpression>;
 }

--- a/src/contracts/sync/request-definition.ts
+++ b/src/contracts/sync/request-definition.ts
@@ -1,0 +1,6 @@
+import type { RequestExpression } from "./request-expression";
+
+/** Body declarativo de uma request de sync. */
+export interface RequestDefinition<TEntity> {
+  body: Record<string, RequestExpression>;
+}

--- a/src/contracts/sync/request-expression.ts
+++ b/src/contracts/sync/request-expression.ts
@@ -1,0 +1,38 @@
+/**
+ * Expressão usada pra montar o body de uma {@link RequestDefinition} de
+ * forma declarativa, sem JavaScript arbitrário — interpretada pelo Native
+ * Sync Engine.
+ */
+export type RequestExpression =
+  | VariableExpression
+  | ConstantExpression
+  | ObjectExpression
+  | ArrayExpression;
+
+/** Referencia uma variável conhecida pelo Native Sync Engine. */
+export interface VariableExpression {
+  $ref:
+    | "cursor" // MVP
+    | "operations" // MVP
+    | "pageSize" // MVP — vem de PaginationDefinition.pageSize
+    | "changes"
+    | "deviceId"
+    | "platform"
+    | "timestamp"
+    | "userId";
+}
+
+/** Valor literal constante. */
+export interface ConstantExpression {
+  value: unknown;
+}
+
+/** Objeto composto por outras {@link RequestExpression}. */
+export interface ObjectExpression {
+  object: Record<string, RequestExpression>;
+}
+
+/** Array composto por outras {@link RequestExpression}. */
+export interface ArrayExpression {
+  items: RequestExpression[];
+}

--- a/src/contracts/sync/response-definition.ts
+++ b/src/contracts/sync/response-definition.ts
@@ -1,7 +1,7 @@
 import type { JsonPath } from "../json-path";
 
 /** Extração declarativa de campos da resposta HTTP de sync. */
-export interface ResponseDefinition<TEntity> {
+export interface ResponseDefinition<_TEntity> {
   cursor?: JsonPath;
 
   operations?: JsonPath;

--- a/src/contracts/sync/response-definition.ts
+++ b/src/contracts/sync/response-definition.ts
@@ -1,0 +1,17 @@
+import type { JsonPath } from "../json-path";
+
+/** Extração declarativa de campos da resposta HTTP de sync. */
+export interface ResponseDefinition<TEntity> {
+  cursor?: JsonPath;
+
+  operations?: JsonPath;
+
+  entities?: JsonPath;
+
+  deleted?: JsonPath;
+
+  metadata?: JsonPath;
+
+  /** MVP: usado junto de PaginationDefinition pra controlar o loop de páginas. */
+  hasMore?: JsonPath;
+}

--- a/src/contracts/sync/retry-definition.ts
+++ b/src/contracts/sync/retry-definition.ts
@@ -1,0 +1,15 @@
+/**
+ * Fora do MVP como contrato por-schema. MVP usa retry fixo e global,
+ * hardcoded no native engine (3 tentativas, 5s delay) — sem chave
+ * declarativa nova, sem `RetryDefinition` referenciado em nenhum
+ * `SyncDefinition`. Este tipo fica reservado.
+ */
+export interface RetryDefinition {
+  enabled: boolean;
+
+  maxAttempts: number;
+
+  backoff: "fixed" | "linear" | "exponential";
+
+  delay: number;
+}

--- a/src/contracts/sync/sync-definition.ts
+++ b/src/contracts/sync/sync-definition.ts
@@ -1,0 +1,38 @@
+import type { SyncDirection } from "./sync-direction";
+import type { SyncStrategy } from "./sync-strategy";
+import type { ConflictStrategy } from "./conflict-strategy";
+import type { Transport } from "./transport";
+import type { EndpointDefinition } from "./endpoint-definition";
+import type { BackgroundDefinition } from "./background-definition";
+import type { PaginationDefinition } from "./pagination-definition";
+import type { RequestDefinition } from "./request-definition";
+import type { ResponseDefinition } from "./response-definition";
+
+/** Contrato de sincronização de um {@link SchemaDefinition}. */
+export interface SyncDefinition<TEntity> {
+  enabled: boolean;
+
+  direction: SyncDirection;
+
+  strategy: SyncStrategy;
+
+  conflict: ConflictStrategy;
+
+  transport: Transport;
+
+  endpoint: EndpointDefinition;
+
+  background?: BackgroundDefinition;
+
+  /**
+   * MVP: presente sempre que strategy = "operations". Controla tanto
+   * o tamanho da página que o engine pede no pull quanto o tamanho do
+   * lote de sync_queue enviado no push — um único número, um único
+   * mental model.
+   */
+  pagination?: PaginationDefinition;
+
+  request: RequestDefinition<TEntity>;
+
+  response: ResponseDefinition<TEntity>;
+}

--- a/src/contracts/sync/sync-direction.ts
+++ b/src/contracts/sync/sync-direction.ts
@@ -1,0 +1,9 @@
+/**
+ * Direção do sync de um {@link SyncDefinition}.
+ *
+ * MVP: só `"bidirectional"` é implementada.
+ */
+export type SyncDirection =
+  | "bidirectional" // MVP: única implementada
+  | "push"
+  | "pull";

--- a/src/contracts/sync/sync-operation.ts
+++ b/src/contracts/sync/sync-operation.ts
@@ -1,0 +1,12 @@
+/** Operação individual da fila de sync (`sync_queue`), gerada por trigger. */
+export interface SyncOperation {
+  operation: "insert" | "update" | "delete";
+
+  entity: string;
+
+  primaryKey: string;
+
+  payload: Record<string, unknown>;
+
+  updatedAt: number;
+}

--- a/src/contracts/sync/sync-strategy.ts
+++ b/src/contracts/sync/sync-strategy.ts
@@ -1,0 +1,9 @@
+/**
+ * Estratégia de sync de um {@link SyncDefinition}.
+ *
+ * MVP: só `"operations"` é implementada.
+ */
+export type SyncStrategy =
+  | "operations" // MVP: única implementada
+  | "incremental"
+  | "full";

--- a/src/contracts/sync/transport.ts
+++ b/src/contracts/sync/transport.ts
@@ -1,0 +1,9 @@
+/**
+ * Protocolo de transporte de um {@link SyncDefinition}.
+ *
+ * MVP: só `"rest"` é implementada.
+ */
+export type Transport =
+  | "rest" // MVP: única implementada
+  | "graphql"
+  | "grpc";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,56 @@
+// Shared
+export type { JsonPath } from "./contracts/json-path";
+
+// Schema contracts
+export type { ColumnDefinition, ColumnTsType } from "./contracts/schema/column-definition";
+export type { IndexDefinition } from "./contracts/schema/index-definition";
+export type { SchemaDefinition } from "./contracts/schema/schema-definition";
+
+// Sync primitives
+export type { HttpMethod } from "./contracts/sync/http-method";
+export type { SyncDirection } from "./contracts/sync/sync-direction";
+export type { SyncStrategy } from "./contracts/sync/sync-strategy";
+export type { ConflictStrategy } from "./contracts/sync/conflict-strategy";
+export type { AuthStrategy } from "./contracts/sync/auth-strategy";
+export type { Transport } from "./contracts/sync/transport";
+export type { AuthProvider } from "./contracts/sync/auth-provider";
+
+// Sync definitions
+export type { AuthenticationDefinition } from "./contracts/sync/authentication-definition";
+export type { CredentialsDefinition } from "./contracts/sync/credentials-definition";
+export type { DatabaseConfigDefinition } from "./contracts/sync/database-config-definition";
+export type { EndpointDefinition } from "./contracts/sync/endpoint-definition";
+export type { BackgroundDefinition } from "./contracts/sync/background-definition";
+export type { PaginationDefinition } from "./contracts/sync/pagination-definition";
+export type {
+  RequestExpression,
+  VariableExpression,
+  ConstantExpression,
+  ObjectExpression,
+  ArrayExpression,
+} from "./contracts/sync/request-expression";
+export type { RequestDefinition } from "./contracts/sync/request-definition";
+export type { ResponseDefinition } from "./contracts/sync/response-definition";
+export type { SyncDefinition } from "./contracts/sync/sync-definition";
+export type { SyncOperation } from "./contracts/sync/sync-operation";
+export type { NativeSyncResult } from "./contracts/sync/native-sync-result";
+export type { RetryDefinition } from "./contracts/sync/retry-definition";
+export type { CompressionDefinition } from "./contracts/sync/compression-definition";
+export type { EncryptionDefinition } from "./contracts/sync/encryption-definition";
+
+// Query / ORM contracts
+export type { CompiledQuery } from "./contracts/query/compiled-query";
+export type { Condition } from "./contracts/query/condition";
+export type { InferSelectModel, InferInsertModel } from "./contracts/query/infer-model";
+export type {
+  QueryClient,
+  SelectQueryBuilder,
+  InsertQueryBuilder,
+  UpdateQueryBuilder,
+  DeleteQueryBuilder,
+} from "./contracts/query/query-client";
+
+// Operator values (declared functions — not types)
+export { eq, ne, gt, gte, lt, lte, like, inArray, isNull, isNotNull, and, or, not } from "./contracts/query/operators";
+
 // TODO: Export all HybridObjects here for the user

--- a/tsconfig.typetest.json
+++ b/tsconfig.typetest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "__typetests__"]
+}


### PR DESCRIPTION
## Summary
- Transcreve os contratos de sync (`docs/architecture.md`) e query/ORM (`docs/query-layer.md`) pra `.ts` real em `src/contracts/`, organizados por domínio (schema/sync/query), um tipo por arquivo salvo grupos coesos (`request-expression`, `operators`, `query-client`+builders)
- Barrel-only `src/index.ts` reexportando todos os contratos + funções operator
- `ColumnTsType` autorado (não existia bloco `.ts` nos docs, só tabela prosa)
- Corrige bug do próprio doc em `InferInsertModel`: `default extends undefined` não detecta ausência de chave opcional nesse contexto genérico (resolve pra `unknown`, não `undefined`) — trocado por `ColumnHasDefault` via `keyof`
- Type-level test (`__typetests__/`) provando `InferSelectModel`/`InferInsertModel` batem com o `CustomerSchema` de `docs/project.md`, checado por `npm run typecheck:contracts` (fora de `src/`, já que `package.json` `files` publica tudo em `src`)
- Marca TASK-001 como ✅ Finalizado em `docs/tasks/001-ts-contracts.md` e `docs/tasks/README.md`

## Test plan
- [x] `npm run typecheck` passa sem erro
- [x] `npm run typecheck:contracts` passa sem erro
- [x] `grep -rnE ':\s*any\b|as any|<any>|\bany\[\]' src` retorna só 1 ocorrência documentada (`AnySchema`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>