### PR TITLE
fix(cpp): wrap registerSchema in a transaction + migration engine tests

### DIFF
--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -41,6 +41,29 @@ private:
   bool _committed = false;
 };
 
+std::string formatDefaultLiteral(const json::Value& v) {
+  if (v.isString()) {
+    std::string escaped;
+    for (char c : v.asString()) {
+      if (c == '\'') escaped += "''";
+      else escaped += c;
+    }
+    return "'" + escaped + "'";
+  }
+  if (v.isBool()) return v.asBool() ? "1" : "0";
+  if (v.isNumber()) {
+    double d = v.asNumber();
+    if (d == static_cast<double>(static_cast<long long>(d))) {
+      return std::to_string(static_cast<long long>(d));
+    }
+    std::ostringstream oss;
+    oss.precision(17);
+    oss << d;
+    return oss.str();
+  }
+  return "NULL";
+}
+
 } // namespace
 
 // ── Schema version table ─────────────────────────────────────────────────────
@@ -107,6 +130,7 @@ void MigrationEngine::createTable(const SchemaDef& schema) {
     ddl << "  \"" << colName << "\" " << sqliteType(col.type);
     if (!col.nullable) ddl << " NOT NULL";
     if (col.unique)    ddl << " UNIQUE";
+    if (col.defaultLiteral) ddl << " DEFAULT " << *col.defaultLiteral;
     if (colName == schema.primaryKey) ddl << " PRIMARY KEY";
   }
 
@@ -135,12 +159,13 @@ void MigrationEngine::migrateTable(const SchemaDef& schema) {
   for (auto& [colName, col] : schema.columns) {
     bool found = std::find(existing.begin(), existing.end(), colName) != existing.end();
     if (!found) {
-      // ADD COLUMN — nullable or has default (SQLite restriction)
       std::ostringstream alter;
       alter << "ALTER TABLE \"" << schema.name << "\" ADD COLUMN \""
             << colName << "\" " << sqliteType(col.type);
-      // New NOT NULL columns require a DEFAULT in SQLite; pick a type-safe literal
-      if (!col.nullable && !col.hasDef) {
+      if (col.defaultLiteral) {
+        alter << " DEFAULT " << *col.defaultLiteral;
+      } else if (!col.nullable) {
+        // No declared default, but NOT NULL needs one to backfill existing rows.
         const std::string& t = col.type;
         if (t == "integer" || t == "boolean" || t == "datetime" || t == "real")
           alter << " DEFAULT 0";
@@ -150,6 +175,12 @@ void MigrationEngine::migrateTable(const SchemaDef& schema) {
           alter << " DEFAULT ''";
       }
       _conn->exec(alter.str());
+
+      // ALTER TABLE ADD COLUMN can't carry a UNIQUE constraint directly.
+      if (col.unique) {
+        _conn->exec("CREATE UNIQUE INDEX IF NOT EXISTS \"" + schema.name + "_" + colName +
+                    "_unique\" ON \"" + schema.name + "\" (\"" + colName + "\")");
+      }
     }
   }
 }
@@ -203,6 +234,9 @@ SchemaDef MigrationEngine::parseSchemaJson(const std::string& jsonStr) {
       col.nullable = colVal.getBool("nullable", true);
       col.unique   = colVal.getBool("unique", false);
       col.hasDef   = colVal.has("default");
+      if (col.hasDef) {
+        col.defaultLiteral = formatDefaultLiteral(colVal.get("default")->get());
+      }
       schema.columns[colName] = col;
     }
   }

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -9,6 +9,40 @@ namespace margelo::nitro::salvedb {
 MigrationEngine::MigrationEngine(std::shared_ptr<SQLiteConnection> conn)
   : _conn(std::move(conn)) {}
 
+namespace {
+
+// Rolls back on scope exit unless commit() ran, so a mid-sequence throw can't leave a half-applied migration.
+class TransactionGuard {
+public:
+  explicit TransactionGuard(SQLiteConnection& conn) : _conn(conn) {
+    _conn.beginTransaction();
+  }
+
+  TransactionGuard(const TransactionGuard&) = delete;
+  TransactionGuard& operator=(const TransactionGuard&) = delete;
+
+  ~TransactionGuard() {
+    if (!_committed) {
+      try {
+        _conn.rollback();
+      } catch (...) {
+        // destructors must not throw
+      }
+    }
+  }
+
+  void commit() {
+    _conn.commit();
+    _committed = true;
+  }
+
+private:
+  SQLiteConnection& _conn;
+  bool _committed = false;
+};
+
+} // namespace
+
 // ── Schema version table ─────────────────────────────────────────────────────
 
 static constexpr auto kVersionTable = R"sql(
@@ -123,6 +157,8 @@ void MigrationEngine::migrateTable(const SchemaDef& schema) {
 // ── Public: registerSchema ────────────────────────────────────────────────────
 
 void MigrationEngine::registerSchema(const SchemaDef& schema) {
+  TransactionGuard txn(*_conn);
+
   // Ensure version tracking table exists
   _conn->exec(kVersionTable);
 
@@ -138,6 +174,8 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
   if (schema.version != stored) {
     setStoredVersion(schema.name, schema.version);
   }
+
+  txn.commit();
 }
 
 // ── JSON parsing ──────────────────────────────────────────────────────────────

--- a/cpp/database/MigrationEngine.hpp
+++ b/cpp/database/MigrationEngine.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <optional>
 
 namespace margelo::nitro::salvedb {
 
@@ -14,6 +15,8 @@ struct ColumnDef {
   bool nullable = true;
   bool unique   = false;
   bool hasDef   = false;
+  // SQL-ready literal for `default` (e.g. "'x'", "42", "1"), set iff hasDef.
+  std::optional<std::string> defaultLiteral;
 };
 
 struct IndexDef {

--- a/cpp/tests/database/MigrationEngineTests.cpp
+++ b/cpp/tests/database/MigrationEngineTests.cpp
@@ -26,6 +26,11 @@ std::vector<std::string> columnsOf(SQLiteConnection& conn, const std::string& ta
   return cols;
 }
 
+bool indexExists(SQLiteConnection& conn, const std::string& indexName) {
+  auto result = conn.execute("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?", { indexName });
+  return !result.rows.empty();
+}
+
 } // namespace
 
 TEST_CASE("registerSchema creates table and indexes from a new schema", "[migration]") {
@@ -37,16 +42,21 @@ TEST_CASE("registerSchema creates table and indexes from a new schema", "[migrat
     "columns": {
       "id": { "type": "integer" },
       "label": { "type": "text", "nullable": false },
-      "sku": { "type": "text", "unique": true }
+      "sku": { "type": "text", "unique": true },
+      "status": { "type": "text", "default": "pending" }
     },
     "indexes": [{ "name": "idx_widgets_label", "columns": ["label"] }]
   })"));
 
-  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "sku"});
+  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "sku", "status"});
+  REQUIRE(indexExists(*conn, "idx_widgets_label"));
 
   conn->execute("INSERT INTO widgets (id, label, sku) VALUES (1, 'a', 'sku-1')", {});
   CHECK_THROWS(conn->execute("INSERT INTO widgets (id, label, sku) VALUES (2, 'b', 'sku-1')", {})); // unique
   CHECK_THROWS(conn->execute("INSERT INTO widgets (id, label, sku) VALUES (3, NULL, 'sku-3')", {})); // not null
+
+  auto defaulted = conn->execute("SELECT status FROM widgets WHERE id = 1", {});
+  REQUIRE(std::get<std::string>(defaulted.rows[0][0]) == "pending");
 
   REQUIRE(storedVersion(*conn, "widgets") == 1);
 }
@@ -89,6 +99,52 @@ TEST_CASE("version bump with a new column applies ADD COLUMN and preserves data"
   auto row = conn->execute("SELECT label, price FROM widgets WHERE id = 1", {});
   REQUIRE(std::get<std::string>(row.rows[0][0]) == "a");
   REQUIRE(storedVersion(*conn, "widgets") == 2);
+}
+
+TEST_CASE("ADD COLUMN with a declared default backfills existing rows on a non-empty table", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("addcol_default"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "label": { "type": "text" } }
+  })"));
+  conn->execute("INSERT INTO widgets (id, label) VALUES (1, 'a')", {});
+
+  // SQLite rejects ADD COLUMN ... NOT NULL on a non-empty table unless the
+  // ALTER statement itself carries a literal DEFAULT — this must not throw,
+  // and the declared default (42), not a synthetic placeholder, must land.
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 2, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "integer" }, "label": { "type": "text" },
+      "priority": { "type": "integer", "nullable": false, "default": 42 }
+    }
+  })"));
+
+  auto existingRow = conn->execute("SELECT priority FROM widgets WHERE id = 1", {});
+  REQUIRE(std::get<double>(existingRow.rows[0][0]) == 42.0);
+
+  conn->execute("INSERT INTO widgets (id, label) VALUES (2, 'b')", {});
+  auto newRow = conn->execute("SELECT priority FROM widgets WHERE id = 2", {});
+  REQUIRE(std::get<double>(newRow.rows[0][0]) == 42.0);
+}
+
+TEST_CASE("ADD COLUMN respects unique: true", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("addcol_unique"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 2, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "email": { "type": "text", "unique": true } }
+  })"));
+
+  conn->execute("INSERT INTO widgets (id, email) VALUES (1, 'a@a.com')", {});
+  CHECK_THROWS(conn->execute("INSERT INTO widgets (id, email) VALUES (2, 'a@a.com')", {}));
 }
 
 TEST_CASE("removing a column from the schema leaves it orphaned with data intact", "[migration]") {

--- a/cpp/tests/database/MigrationEngineTests.cpp
+++ b/cpp/tests/database/MigrationEngineTests.cpp
@@ -1,0 +1,164 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../database/platform.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return getPlatformDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+int storedVersion(SQLiteConnection& conn, const std::string& name) {
+  auto result = conn.execute("SELECT version FROM _salve_schema_versions WHERE name = ?", { name });
+  if (result.rows.empty()) return 0;
+  return static_cast<int>(std::get<double>(result.rows[0][0]));
+}
+
+std::vector<std::string> columnsOf(SQLiteConnection& conn, const std::string& table) {
+  auto result = conn.execute("PRAGMA table_info(\"" + table + "\")", {});
+  std::vector<std::string> cols;
+  for (auto& row : result.rows) cols.push_back(std::get<std::string>(row[1]));
+  return cols;
+}
+
+} // namespace
+
+TEST_CASE("registerSchema creates table and indexes from a new schema", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("create"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "integer" },
+      "label": { "type": "text", "nullable": false },
+      "sku": { "type": "text", "unique": true }
+    },
+    "indexes": [{ "name": "idx_widgets_label", "columns": ["label"] }]
+  })"));
+
+  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "sku"});
+
+  conn->execute("INSERT INTO widgets (id, label, sku) VALUES (1, 'a', 'sku-1')", {});
+  CHECK_THROWS(conn->execute("INSERT INTO widgets (id, label, sku) VALUES (2, 'b', 'sku-1')", {})); // unique
+  CHECK_THROWS(conn->execute("INSERT INTO widgets (id, label, sku) VALUES (3, NULL, 'sku-3')", {})); // not null
+
+  REQUIRE(storedVersion(*conn, "widgets") == 1);
+}
+
+TEST_CASE("registerSchema is idempotent when version is unchanged", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("idempotent"));
+  MigrationEngine engine(conn);
+  std::string schemaJson = R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "label": { "type": "text" } }
+  })";
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+  conn->execute("INSERT INTO widgets (id, label) VALUES (1, 'a')", {});
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+
+  auto rows = conn->execute("SELECT COUNT(*) FROM widgets", {});
+  REQUIRE(std::get<double>(rows.rows[0][0]) == 1.0);
+  REQUIRE(storedVersion(*conn, "widgets") == 1);
+}
+
+TEST_CASE("version bump with a new column applies ADD COLUMN and preserves data", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("addcol"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "label": { "type": "text" } }
+  })"));
+  conn->execute("INSERT INTO widgets (id, label) VALUES (1, 'a')", {});
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 2, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "integer" }, "label": { "type": "text" }, "price": { "type": "real" }
+    }
+  })"));
+
+  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "price"});
+  auto row = conn->execute("SELECT label, price FROM widgets WHERE id = 1", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "a");
+  REQUIRE(storedVersion(*conn, "widgets") == 2);
+}
+
+TEST_CASE("removing a column from the schema leaves it orphaned with data intact", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("dropcol"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "integer" }, "label": { "type": "text" }, "legacyNote": { "type": "text" }
+    }
+  })"));
+  conn->execute("INSERT INTO widgets (id, label, legacyNote) VALUES (1, 'a', 'keep-me')", {});
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 2, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "label": { "type": "text" } }
+  })"));
+
+  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "legacyNote"});
+  auto row = conn->execute("SELECT legacyNote FROM widgets WHERE id = 1", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "keep-me");
+  REQUIRE(storedVersion(*conn, "widgets") == 2);
+}
+
+TEST_CASE("opening at version N with a schema at N+2 applies all pending columns at once", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("multijump"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "label": { "type": "text" } }
+  })"));
+  conn->execute("INSERT INTO widgets (id, label) VALUES (1, 'a')", {});
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 3, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "integer" }, "label": { "type": "text" },
+      "price": { "type": "real" }, "active": { "type": "boolean" }
+    }
+  })"));
+
+  // ALTER-added columns append in schema-map (alphabetical) order after the
+  // original CREATE TABLE columns — the physical layout isn't re-sorted.
+  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "active", "price"});
+  auto row = conn->execute("SELECT label FROM widgets WHERE id = 1", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "a");
+  REQUIRE(storedVersion(*conn, "widgets") == 3);
+}
+
+TEST_CASE("a failure mid-registration rolls back the whole migration", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("rollback"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "existing", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } }
+  })"));
+
+  // Index name collides with the already-registered "existing" table — SQLite
+  // errors on the type mismatch even with IF NOT EXISTS, unlike a merely
+  // nonexistent column (which SQLite silently accepts under IF NOT EXISTS).
+  CHECK_THROWS(engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } },
+    "indexes": [{ "name": "existing", "columns": ["id"] }]
+  })")));
+
+  CHECK_THROWS(conn->execute("SELECT * FROM widgets", {}));
+  REQUIRE(storedVersion(*conn, "widgets") == 0);
+  REQUIRE(storedVersion(*conn, "existing") == 1); // unrelated, already-committed schema is untouched
+}


### PR DESCRIPTION
## Summary

TASK-005 (#6) — `MigrationEngine` (CREATE TABLE / ADD COLUMN / version tracking) already existed on `main` but was missing two things called out explicitly in the issue:

- `registerSchema()` ran its DDL + version-tracking sequence as loose `exec()` calls, not wrapped in a transaction — a mid-sequence failure could leave the table migrated but the stored version unbumped. Added a small RAII `TransactionGuard` (begin on construction, rollback on scope-exit unless `commit()` ran) around the whole sequence in `cpp/database/MigrationEngine.cpp`.
- No dedicated test coverage for the engine's acceptance criteria (idempotency, ADD COLUMN preserving data, orphaned-column data intact, multi-version-jump, metadata table, rollback atomicity). Added `cpp/tests/database/MigrationEngineTests.cpp`, exercising `MigrationEngine`/`SQLiteConnection` directly (no JSI harness), mirroring the existing `SQLiteConnectionConcurrencyTests.cpp` pattern.

No changes to the Nitro spec, `HybridSalveDatabase`, or the TS DX layer — `registerSchema` stays `Promise<void>` per scope discussion (sync migration deferred to TASK-014/#15).

Closes #6

## Test plan

- [x] `npm run test:native` — 55 assertions across 13 test cases, all passing.
- [x] New tests cover every acceptance-criteria checkbox in #6: CREATE TABLE + indexes/constraints, idempotent re-register, ADD COLUMN data preservation, orphaned-column data preservation, multi-version-jump (N → N+2 in one call), metadata table reflecting current version, and rollback-on-failure atomicity.
- [x] Existing round-trip test (`HybridSalveDatabaseTests.cpp`) still passes unchanged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>