### PR TITLE
refactor: inject nitro bridge via constructor

### DIFF
--- a/cpp/database/HybridSalveDatabase.cpp
+++ b/cpp/database/HybridSalveDatabase.cpp
@@ -23,8 +23,9 @@ std::shared_ptr<Promise<void>> HybridSalveDatabase::registerSchema(const std::st
 }
 
 QueryResult HybridSalveDatabase::execute(
-    const std::string& sql,
-    const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params) {
+  const std::string& sql,
+  const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params
+) {
   return _queryExecutor.execute(sql, params);
 }
 

--- a/src/database/Database.class.ts
+++ b/src/database/Database.class.ts
@@ -1,10 +1,14 @@
+import type { SalveDatabase } from '../specs/SalveDatabase.nitro';
 import type { AnySchema } from '../types';
 import type { IConfigureProps, IQueryClient, IRegisterProps } from './classes';
+import { NitroModules } from 'react-native-nitro-modules';
 import { ConfigureDb, QueryDb } from './classes';
 
+const _bridge = NitroModules.createHybridObject<SalveDatabase>('SalveDatabase');
+
 export class Database {
-  private static readonly configureDb = new ConfigureDb()
-  private static readonly queryDb = new QueryDb()
+  private static readonly configureDb = new ConfigureDb(_bridge)
+  private static readonly queryDb = new QueryDb(_bridge)
 
   private constructor() {}
 

--- a/src/database/classes/ConfigureDb/ConfigureDb.class.ts
+++ b/src/database/classes/ConfigureDb/ConfigureDb.class.ts
@@ -1,9 +1,6 @@
 import type { SalveDatabase } from '../../../specs/SalveDatabase.nitro';
 import type { IConfigureProps, ICredentialsDefinition, IRegisterProps } from './types';
 import type { ConfigureParams } from '../../../specs/types/ConfigureParams';
-import { NitroModules } from 'react-native-nitro-modules';
-
-const _bridge = NitroModules.createHybridObject<SalveDatabase>('SalveDatabase');
 
 function mapCredentials(creds: ICredentialsDefinition): ConfigureParams['credentials'] {
   switch (creds.provider) {
@@ -23,14 +20,14 @@ function mapCredentials(creds: ICredentialsDefinition): ConfigureParams['credent
 export class ConfigureDb {
   private static _configured = false;
 
-  constructor() {}
+  constructor(private readonly _bridge: SalveDatabase) {}
 
   configure(props: IConfigureProps): void {
     if (!props.name || props.name.trim() === '') {
       throw new Error("Database.configure: 'name' is required");
     }
 
-    _bridge.configure({
+    this._bridge.configure({
       name: props.name,
       baseUrl: props.baseUrl,
       network: props.network,
@@ -59,7 +56,7 @@ export class ConfigureDb {
       );
     }
 
-    return _bridge.registerSchema(JSON.stringify(schema));
+    return this._bridge.registerSchema(JSON.stringify(schema));
   }
 
   static isConfigured(): boolean {

--- a/src/database/classes/QueryDb/QueryDb.class.ts
+++ b/src/database/classes/QueryDb/QueryDb.class.ts
@@ -2,52 +2,49 @@ import type { SalveDatabase } from '../../../specs/SalveDatabase.nitro';
 import type { SqlValue } from '../../../specs/types';
 import type { IQueryClient } from './types';
 import type { AnySchema } from '../../../types';
-import { NitroModules } from 'react-native-nitro-modules';
 import { SelectQueryBuilder, InsertQueryBuilder, UpdateQueryBuilder, DeleteQueryBuilder } from './classes';
 import { ConfigureDb } from '../ConfigureDb';
 
-const _bridge = NitroModules.createHybridObject<SalveDatabase>('SalveDatabase');
-
 export class QueryDb {
-  constructor() {}
+  constructor(private readonly _bridge: SalveDatabase) {}
 
   select<TSchema extends AnySchema>(schema: TSchema) {
     this._assertConfigured('select');
-    return new SelectQueryBuilder(schema, _bridge);
+    return new SelectQueryBuilder(schema, this._bridge);
   }
 
   insert<TSchema extends AnySchema>(schema: TSchema) {
     this._assertConfigured('insert');
-    return new InsertQueryBuilder(schema, _bridge);
+    return new InsertQueryBuilder(schema, this._bridge);
   }
 
   update<TSchema extends AnySchema>(schema: TSchema) {
     this._assertConfigured('update');
-    return new UpdateQueryBuilder(schema, _bridge);
+    return new UpdateQueryBuilder(schema, this._bridge);
   }
 
   delete<TSchema extends AnySchema>(schema: TSchema) {
     this._assertConfigured('delete');
-    return new DeleteQueryBuilder(schema, _bridge);
+    return new DeleteQueryBuilder(schema, this._bridge);
   }
 
   transaction<T>(fn: (tx: IQueryClient) => T): T {
     this._assertConfigured('transaction');
-    _bridge.beginTransaction();
+    this._bridge.beginTransaction();
 
     try {
       const result = fn(this._makeTxClient());
-      _bridge.commit();
+      this._bridge.commit();
       return result;
     } catch (err) {
-      _bridge.rollback();
+      this._bridge.rollback();
       throw err;
     }
   }
 
   execute(sql: string, params?: unknown[]): unknown[] {
     this._assertConfigured('execute');
-    const result = _bridge.execute(sql, (params ?? []) as SqlValue[]);
+    const result = this._bridge.execute(sql, (params ?? []) as SqlValue[]);
 
     return result.rows.map((row) => {
       const obj: Record<string, unknown> = {};
@@ -65,16 +62,16 @@ export class QueryDb {
   private _makeTxClient(): IQueryClient {
     return {
       select: <TSchema extends AnySchema>(schema: TSchema) =>
-        new SelectQueryBuilder(schema, _bridge),
+        new SelectQueryBuilder(schema, this._bridge),
 
       insert: <TSchema extends AnySchema>(schema: TSchema) =>
-        new InsertQueryBuilder(schema, _bridge),
+        new InsertQueryBuilder(schema, this._bridge),
 
       update: <TSchema extends AnySchema>(schema: TSchema) =>
-        new UpdateQueryBuilder(schema, _bridge),
+        new UpdateQueryBuilder(schema, this._bridge),
 
       delete: <TSchema extends AnySchema>(schema: TSchema) =>
-        new DeleteQueryBuilder(schema, _bridge),
+        new DeleteQueryBuilder(schema, this._bridge),
 
       transaction: <T>(fn: (tx: IQueryClient) => T) =>
         this.transaction(fn),


### PR DESCRIPTION
## 📋 What changes

Centralizes the Nitro `SalveDatabase` HybridObject into a single instance created in `Database.class.ts` and injects it via constructor into `ConfigureDb` and `QueryDb`, removing the duplicate `createHybridObject` calls.

**Task:** TASK-XXX — [n/a]

---

## 🏷️ Type

- [ ] ✨ feat — new feature
- [ ] 🐛 fix — bug fix
- [ ] 🔧 build — build config / dependencies
- [x] ♻️ refactor — restructuring without behavior change
- [ ] 🧪 test — tests / harness
- [ ] 📝 docs

---

## 🔌 Native context _(fill in if touching C++ / Swift / Kotlin)_

No bridge behavior change. The only C++ touch is a formatting-only reformat of the `execute` signature in `HybridSalveDatabase.cpp` (no logic change). No new/modified HybridObject; `npm run codegen` not required.

---

## ✅ Checklist

- [ ] \`npm run codegen\` passes without errors
- [ ] TypeScript compiles without errors (\`tsc --noEmit\`)
- [ ] iOS and Android harness passes (or not applicable)
- [ ] \`nitrogen/generated/\` is up to date in the commit (if applicable)