### PR TITLE
feat(sync): TASK-006 trigger engine & sync queue

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/database/MigrationEngine.cpp
 	../cpp/query/QueryExecutor.cpp
 	../cpp/sync/SyncOrchestrator.cpp
+	../cpp/sync/SyncApplyGuard.cpp
 )
 
 # Add Nitrogen specs :)

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -75,6 +75,25 @@ static constexpr auto kVersionTable = R"sql(
   );
 )sql";
 
+// ── Sync queue / apply lock (global, created once regardless of schema) ──────
+
+static constexpr auto kSyncQueueTable = R"sql(
+  CREATE TABLE IF NOT EXISTS sync_queue (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation  TEXT    NOT NULL,
+    entity     TEXT    NOT NULL,
+    entity_id  TEXT    NOT NULL,
+    payload    TEXT    NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+)sql";
+
+static constexpr auto kSyncApplyLockTable = R"sql(
+  CREATE TABLE IF NOT EXISTS _sync_apply_lock (
+    id INTEGER PRIMARY KEY CHECK (id = 1)
+  );
+)sql";
+
 int MigrationEngine::storedVersion(const std::string& schemaName) {
   auto result = _conn->execute(
     "SELECT version FROM _salve_schema_versions WHERE name = ?",
@@ -153,12 +172,14 @@ void MigrationEngine::createTable(const SchemaDef& schema) {
 
 // ── ALTER TABLE ADD COLUMN (migration) ───────────────────────────────────────
 
-void MigrationEngine::migrateTable(const SchemaDef& schema) {
+bool MigrationEngine::migrateTable(const SchemaDef& schema) {
   auto existing = existingColumns(schema.name);
+  bool added = false;
 
   for (auto& [colName, col] : schema.columns) {
     bool found = std::find(existing.begin(), existing.end(), colName) != existing.end();
     if (!found) {
+      added = true;
       std::ostringstream alter;
       alter << "ALTER TABLE \"" << schema.name << "\" ADD COLUMN \""
             << colName << "\" " << sqliteType(col.type);
@@ -183,6 +204,75 @@ void MigrationEngine::migrateTable(const SchemaDef& schema) {
       }
     }
   }
+
+  return added;
+}
+
+// ── Sync triggers ──────────────────────────────────────────────────────────
+
+namespace {
+
+std::string buildJsonObjectArgs(const SchemaDef& schema, const std::string& rowAlias) {
+  std::ostringstream args;
+  bool first = true;
+  for (auto& [colName, col] : schema.columns) {
+    if (!first) args << ", ";
+    first = false;
+    args << "'" << colName << "', " << rowAlias << ".\"" << colName << "\"";
+  }
+  return args.str();
+}
+
+} // namespace
+
+void MigrationEngine::createSyncTriggers(const SchemaDef& schema) {
+  const std::string& t  = schema.name;
+  const std::string& pk = schema.primaryKey;
+  std::string rowCols = buildJsonObjectArgs(schema, "NEW");
+
+  std::ostringstream insertTrig;
+  insertTrig << "CREATE TRIGGER IF NOT EXISTS \"" << t << "_sync_after_insert\"\n"
+             << "AFTER INSERT ON \"" << t << "\"\n"
+             << "WHEN NOT EXISTS (SELECT 1 FROM _sync_apply_lock)\n"
+             << "BEGIN\n"
+             << "  INSERT INTO sync_queue (operation, entity, entity_id, payload, updated_at)\n"
+             << "  VALUES ('insert', '" << t << "', NEW.\"" << pk << "\",\n"
+             << "    json_object(" << rowCols << "),\n"
+             << "    CAST(strftime('%s','now') * 1000 AS INTEGER));\n"
+             << "END;";
+  _conn->exec(insertTrig.str());
+
+  std::ostringstream updateTrig;
+  updateTrig << "CREATE TRIGGER IF NOT EXISTS \"" << t << "_sync_after_update\"\n"
+             << "AFTER UPDATE ON \"" << t << "\"\n"
+             << "WHEN NOT EXISTS (SELECT 1 FROM _sync_apply_lock)\n"
+             << "BEGIN\n"
+             << "  INSERT INTO sync_queue (operation, entity, entity_id, payload, updated_at)\n"
+             << "  VALUES ('update', '" << t << "', NEW.\"" << pk << "\",\n"
+             << "    json_object(" << rowCols << "),\n"
+             << "    CAST(strftime('%s','now') * 1000 AS INTEGER));\n"
+             << "END;";
+  _conn->exec(updateTrig.str());
+
+  // PK-only payload: the row is already gone by the time AFTER DELETE fires.
+  std::ostringstream deleteTrig;
+  deleteTrig << "CREATE TRIGGER IF NOT EXISTS \"" << t << "_sync_after_delete\"\n"
+             << "AFTER DELETE ON \"" << t << "\"\n"
+             << "WHEN NOT EXISTS (SELECT 1 FROM _sync_apply_lock)\n"
+             << "BEGIN\n"
+             << "  INSERT INTO sync_queue (operation, entity, entity_id, payload, updated_at)\n"
+             << "  VALUES ('delete', '" << t << "', OLD.\"" << pk << "\",\n"
+             << "    json_object('" << pk << "', OLD.\"" << pk << "\"),\n"
+             << "    CAST(strftime('%s','now') * 1000 AS INTEGER));\n"
+             << "END;";
+  _conn->exec(deleteTrig.str());
+}
+
+void MigrationEngine::dropSyncTriggers(const SchemaDef& schema) {
+  const std::string& t = schema.name;
+  _conn->exec("DROP TRIGGER IF EXISTS \"" + t + "_sync_after_insert\";");
+  _conn->exec("DROP TRIGGER IF EXISTS \"" + t + "_sync_after_update\";");
+  _conn->exec("DROP TRIGGER IF EXISTS \"" + t + "_sync_after_delete\";");
 }
 
 // ── Public: registerSchema ────────────────────────────────────────────────────
@@ -190,17 +280,30 @@ void MigrationEngine::migrateTable(const SchemaDef& schema) {
 void MigrationEngine::registerSchema(const SchemaDef& schema) {
   TransactionGuard txn(*_conn);
 
-  // Ensure version tracking table exists
   _conn->exec(kVersionTable);
+  _conn->exec(kSyncQueueTable);
+  _conn->exec(kSyncApplyLockTable);
 
   int stored = storedVersion(schema.name);
+  bool columnsChanged = false;
 
   if (stored == 0) {
     createTable(schema);
+    columnsChanged = true;
   } else if (schema.version > stored) {
-    migrateTable(schema);
+    columnsChanged = migrateTable(schema);
   }
   // If schema.version == stored, nothing to do (idempotent)
+
+  if (schema.sync.enabled) {
+    // Triggers are CREATE ... IF NOT EXISTS, so a stale json_object(...) needs an explicit drop+recreate.
+    if (columnsChanged) {
+      dropSyncTriggers(schema);
+      createSyncTriggers(schema);
+    }
+  } else {
+    dropSyncTriggers(schema); // no-op unless sync was previously enabled
+  }
 
   if (schema.version != stored) {
     setStoredVersion(schema.name, schema.version);
@@ -258,6 +361,11 @@ SchemaDef MigrationEngine::parseSchemaJson(const std::string& jsonStr) {
         schema.indexes.push_back(std::move(idx));
       }
     }
+  }
+
+  auto syncVal = root.get("sync");
+  if (syncVal && syncVal->get().isObject()) {
+    schema.sync.enabled = syncVal->get().getBool("enabled", false);
   }
 
   return schema;

--- a/cpp/database/MigrationEngine.hpp
+++ b/cpp/database/MigrationEngine.hpp
@@ -25,12 +25,17 @@ struct IndexDef {
   bool unique = false;
 };
 
+struct SyncSettings {
+  bool enabled = false;
+};
+
 struct SchemaDef {
   std::string name;
   int version = 1;
   std::string primaryKey;
   std::map<std::string, ColumnDef> columns;
   std::vector<IndexDef> indexes;
+  SyncSettings sync;
 };
 
 class MigrationEngine {
@@ -46,13 +51,16 @@ private:
   std::shared_ptr<SQLiteConnection> _conn;
 
   void createTable(const SchemaDef& schema);
-  void migrateTable(const SchemaDef& schema);
+  bool migrateTable(const SchemaDef& schema); // true if a column was added
 
   int storedVersion(const std::string& schemaName);
   void setStoredVersion(const std::string& schemaName, int version);
 
   std::string sqliteType(const std::string& colType) const;
   std::vector<std::string> existingColumns(const std::string& tableName);
+
+  void createSyncTriggers(const SchemaDef& schema);
+  void dropSyncTriggers(const SchemaDef& schema);
 };
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncApplyGuard.cpp
+++ b/cpp/sync/SyncApplyGuard.cpp
@@ -1,0 +1,53 @@
+#include "SyncApplyGuard.hpp"
+
+namespace margelo::nitro::salvedb {
+
+namespace {
+
+class ApplyTransactionGuard {
+public:
+  explicit ApplyTransactionGuard(SQLiteConnection& conn) : _conn(conn) {
+    _conn.beginTransaction();
+  }
+
+  ApplyTransactionGuard(const ApplyTransactionGuard&) = delete;
+  ApplyTransactionGuard& operator=(const ApplyTransactionGuard&) = delete;
+
+  ~ApplyTransactionGuard() {
+    if (!_committed) {
+      try {
+        _conn.rollback();
+      } catch (...) {
+        // destructors must not throw
+      }
+    }
+  }
+
+  void commit() {
+    _conn.commit();
+    _committed = true;
+  }
+
+private:
+  SQLiteConnection& _conn;
+  bool _committed = false;
+};
+
+} // namespace
+
+SyncApplyGuard::SyncApplyGuard(std::shared_ptr<SQLiteConnection> conn)
+  : _conn(std::move(conn)) {}
+
+void SyncApplyGuard::applyWithBypass(const std::function<void()>& fn) {
+  ApplyTransactionGuard txn(*_conn);
+
+  _conn->exec("INSERT OR IGNORE INTO _sync_apply_lock (id) VALUES (1)");
+
+  fn();
+
+  _conn->exec("DELETE FROM _sync_apply_lock");
+
+  txn.commit();
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncApplyGuard.hpp
+++ b/cpp/sync/SyncApplyGuard.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../database/SQLiteConnection.hpp"
+#include <functional>
+#include <memory>
+
+namespace margelo::nitro::salvedb {
+
+// Encapsulates BEGIN/lock/apply/unlock/COMMIT so downstream sync-apply code
+// (TASK-012) never has to hand-roll the _sync_apply_lock bypass SQL.
+class SyncApplyGuard {
+public:
+  explicit SyncApplyGuard(std::shared_ptr<SQLiteConnection> conn);
+
+  // Runs fn() inside a transaction with _sync_apply_lock held, so writes
+  // fn() performs don't get re-queued into sync_queue by the sync triggers.
+  // If fn() throws, the whole transaction (writes + lock row) rolls back.
+  void applyWithBypass(const std::function<void()>& fn);
+
+private:
+  std::shared_ptr<SQLiteConnection> _conn;
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/database/MigrationEngine.cpp"
   "${PROJECT_CPP_DIR}/query/QueryExecutor.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncOrchestrator.cpp"
+  "${PROJECT_CPP_DIR}/sync/SyncApplyGuard.cpp"
   "${PROJECT_CPP_DIR}/third_party/sqlite3/sqlite3.c"
   "${GENERATED_CPP_DIR}/HybridSalveDatabaseSpec.cpp"
 )

--- a/cpp/tests/database/MigrationEngineTests.cpp
+++ b/cpp/tests/database/MigrationEngineTests.cpp
@@ -218,3 +218,124 @@ TEST_CASE("a failure mid-registration rolls back the whole migration", "[migrati
   REQUIRE(storedVersion(*conn, "widgets") == 0);
   REQUIRE(storedVersion(*conn, "existing") == 1); // unrelated, already-committed schema is untouched
 }
+
+namespace {
+
+bool tableExists(SQLiteConnection& conn, const std::string& name) {
+  auto r = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?", { name });
+  return !r.rows.empty();
+}
+
+int triggerCount(SQLiteConnection& conn, const std::string& tableName) {
+  auto r = conn.execute("SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?", { tableName });
+  return static_cast<int>(std::get<double>(r.rows[0][0]));
+}
+
+std::string triggerSql(SQLiteConnection& conn, const std::string& name) {
+  auto r = conn.execute("SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = ?", { name });
+  REQUIRE(!r.rows.empty());
+  return std::get<std::string>(r.rows[0][0]);
+}
+
+} // namespace
+
+TEST_CASE("sync_queue and _sync_apply_lock are created once and survive repeated registerSchema", "[migration][sync]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("sync_tables_once"));
+  MigrationEngine engine(conn);
+  std::string schemaJson = R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } }
+  })";
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+  REQUIRE(tableExists(*conn, "sync_queue"));
+  REQUIRE(tableExists(*conn, "_sync_apply_lock"));
+
+  conn->execute(
+    "INSERT INTO sync_queue (operation, entity, entity_id, payload, updated_at) VALUES ('insert','widgets','1','{}',0)", {});
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+
+  auto rows = conn->execute("SELECT COUNT(*) FROM sync_queue", {});
+  REQUIRE(std::get<double>(rows.rows[0][0]) == 1.0);
+}
+
+TEST_CASE("sync.enabled: true creates 3 triggers matching schema.columns", "[migration][sync]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("sync_triggers"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" }, "phone": { "type": "text" } },
+    "sync": { "enabled": true }
+  })"));
+
+  REQUIRE(triggerCount(*conn, "customers") == 3);
+
+  auto insertSql = triggerSql(*conn, "customers_sync_after_insert");
+  REQUIRE(insertSql.find("json_object('id', NEW.\"id\", 'name', NEW.\"name\", 'phone', NEW.\"phone\")") != std::string::npos);
+
+  auto updateSql = triggerSql(*conn, "customers_sync_after_update");
+  REQUIRE(updateSql.find("json_object('id', NEW.\"id\", 'name', NEW.\"name\", 'phone', NEW.\"phone\")") != std::string::npos);
+
+  auto deleteSql = triggerSql(*conn, "customers_sync_after_delete");
+  REQUIRE(deleteSql.find("json_object('id', OLD.\"id\")") != std::string::npos);
+  REQUIRE(deleteSql.find("'name'") == std::string::npos); // delete payload is PK-only
+}
+
+TEST_CASE("sync.enabled: false or absent creates no triggers", "[migration][sync]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("sync_disabled"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "no_sync_field", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } }
+  })"));
+  REQUIRE(triggerCount(*conn, "no_sync_field") == 0);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "sync_off", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } },
+    "sync": { "enabled": false }
+  })"));
+  REQUIRE(triggerCount(*conn, "sync_off") == 0);
+}
+
+TEST_CASE("migrating a sync-enabled schema with a new column regenerates triggers", "[migration][sync]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("sync_migrate_regen"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" } },
+    "sync": { "enabled": true }
+  })"));
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 2, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" }, "phone": { "type": "text" } },
+    "sync": { "enabled": true }
+  })"));
+
+  REQUIRE(triggerCount(*conn, "customers") == 3);
+  auto insertSql = triggerSql(*conn, "customers_sync_after_insert");
+  REQUIRE(insertSql.find("'phone', NEW.\"phone\"") != std::string::npos);
+}
+
+TEST_CASE("turning sync.enabled off across versions drops orphaned triggers", "[migration][sync]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("sync_toggle_off"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } },
+    "sync": { "enabled": true }
+  })"));
+  REQUIRE(triggerCount(*conn, "customers") == 3);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 2, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "note": { "type": "text" } },
+    "sync": { "enabled": false }
+  })"));
+  REQUIRE(triggerCount(*conn, "customers") == 0);
+}

--- a/cpp/tests/sync/SyncApplyGuardTests.cpp
+++ b/cpp/tests/sync/SyncApplyGuardTests.cpp
@@ -1,0 +1,80 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../platform/platform.hpp"
+#include "../../sync/SyncApplyGuard.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return platform::getDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+void registerSyncEnabledCustomers(MigrationEngine& engine) {
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" } },
+    "sync": { "enabled": true }
+  })"));
+}
+
+} // namespace
+
+TEST_CASE("direct writes outside any apply lock enqueue sync_queue entries", "[sync][SyncApplyGuard]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("direct_writes"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+  conn->execute("UPDATE customers SET name = 'b' WHERE id = 1", {});
+  conn->execute("DELETE FROM customers WHERE id = 1", {});
+
+  auto rows = conn->execute("SELECT operation FROM sync_queue WHERE entity = 'customers' ORDER BY id", {});
+  REQUIRE(rows.rows.size() == 3);
+  REQUIRE(std::get<std::string>(rows.rows[0][0]) == "insert");
+  REQUIRE(std::get<std::string>(rows.rows[1][0]) == "update");
+  REQUIRE(std::get<std::string>(rows.rows[2][0]) == "delete");
+}
+
+TEST_CASE("writes performed inside applyWithBypass are not queued", "[sync][SyncApplyGuard]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("bypass_writes"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  SyncApplyGuard guard(conn);
+  guard.applyWithBypass([&]() {
+    conn->execute("INSERT INTO customers (id, name) VALUES (1, 'from-server')", {});
+    conn->execute("UPDATE customers SET name = 'still-from-server' WHERE id = 1", {});
+  });
+
+  auto rows = conn->execute("SELECT COUNT(*) FROM sync_queue WHERE entity = 'customers'", {});
+  REQUIRE(std::get<double>(rows.rows[0][0]) == 0.0);
+
+  auto data = conn->execute("SELECT name FROM customers WHERE id = 1", {});
+  REQUIRE(std::get<std::string>(data.rows[0][0]) == "still-from-server");
+}
+
+TEST_CASE("a failed apply rolls back the lock, and normal writes resume being tracked", "[sync][SyncApplyGuard]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("bypass_rollback"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  SyncApplyGuard guard(conn);
+  CHECK_THROWS(guard.applyWithBypass([&]() {
+    conn->execute("INSERT INTO customers (id, name) VALUES (1, 'partial')", {});
+    conn->execute("INSERT INTO no_such_table (id) VALUES (1)", {}); // forces failure mid-apply
+  }));
+
+  auto customerRows = conn->execute("SELECT COUNT(*) FROM customers", {});
+  REQUIRE(std::get<double>(customerRows.rows[0][0]) == 0.0);
+  auto lockRows = conn->execute("SELECT COUNT(*) FROM _sync_apply_lock", {});
+  REQUIRE(std::get<double>(lockRows.rows[0][0]) == 0.0);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (2, 'normal-write')", {});
+  auto queued = conn->execute("SELECT COUNT(*) FROM sync_queue WHERE entity_id = '2'", {});
+  REQUIRE(std::get<double>(queued.rows[0][0]) == 1.0);
+}


### PR DESCRIPTION
## Summary

- `sync_queue`/`_sync_apply_lock` created once (idempotent) inside `MigrationEngine::registerSchema`, following the same lazy `CREATE TABLE IF NOT EXISTS` pattern already used for `_salve_schema_versions`.
- Per sync-enabled schema, generates the 3 `AFTER INSERT/UPDATE/DELETE` triggers (dynamic `json_object(...)` from `schema.columns`, delete payload is PK-only by design) that log to `sync_queue` unless `_sync_apply_lock` is held.
- New `SyncApplyGuard` class (`cpp/sync/`) exposing `applyWithBypass(fn)` — encapsulates `BEGIN`/lock/`fn`/unlock/`COMMIT` as one transaction so a mid-apply failure can't leave the lock stuck. TASK-012 will call this, not reimplement the SQL.

## Scope note (why this touches more than the issue's literal checklist)

TASK-006 (#7) assumed `sync.enabled` was already available on the native side via TASK-005 — it wasn't. `SchemaDef`/`parseSchemaJson` never read the `sync` block, so acceptance criteria 2/3 (create/skip triggers based on `sync.enabled`) were unsatisfiable as written. This PR extends `SchemaDef` with a `SyncSettings` field and parses `sync.enabled` from the schema JSON as a prerequisite.

Two gaps found during scoping (not in the issue's original checklist, resolved here rather than deferred):
- **Trigger regeneration on migration**: triggers use `CREATE TRIGGER IF NOT EXISTS`, so a migration that adds a column would otherwise never refresh the trigger's `json_object(...)` list, silently dropping the new column from sync forever. `migrateTable` now returns whether a column was added; `registerSchema` drops+recreates triggers when it did.
- **`sync.enabled` toggled off across versions**: drops orphaned triggers so a schema that stops being sync-enabled doesn't keep logging to `sync_queue`.

`applyWithBypass` lives in a new dedicated class (`SyncApplyGuard`) rather than `MigrationEngine`, per discussion — it duplicates a small RAII transaction-guard idiom already used privately in `MigrationEngine.cpp` rather than extracting a shared header for two callers. Its signature is `applyWithBypass(std::function<void()> fn)` rather than the issue's literal `(operations, fn)`, since this class doesn't know `SyncOperation`'s shape — that's TASK-012's concern; the future caller closes over its own operations inside the lambda.

## Test plan

- [x] `npm run test:native` — 23 test cases / 88 assertions passing, including 8 new cases covering every TASK-006 acceptance criterion plus the two extra gaps above.
- [x] `sync_queue`/`_sync_apply_lock` created once and survive repeated `registerSchema`.
- [x] `sync.enabled: true` → 3 triggers, `json_object` matches `schema.columns` exactly.
- [x] `sync.enabled: false`/absent → no triggers.
- [x] Direct writes enqueue; writes inside `applyWithBypass` don't.
- [x] Failed apply rolls back fully (data + lock), next normal write is tracked again.
- [x] Migration adding a column regenerates triggers with the updated column list.
- [x] `sync.enabled` flipping to `false` across versions drops orphaned triggers.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)