### PR TITLE
TASK-007: coerce boolean columns, distinguish SQL errors

### DIFF
--- a/SalveDb.podspec
+++ b/SalveDb.podspec
@@ -25,6 +25,9 @@ Pod::Spec.new do |s|
   ]
   s.exclude_files = "cpp/tests/**/*"
 
+  # Needed for sqlite3_column_table_name/origin_name, used to coerce boolean columns on read.
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SQLITE_ENABLE_COLUMN_METADATA=1' }
+
   load 'nitrogen/generated/ios/SalveDb+autolinking.rb'
   add_nitrogen_files(s)
 

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -7,6 +7,8 @@ set (CMAKE_CXX_STANDARD 20)
 
 # Enable Raw Props parsing in react-native (for Nitro Views)
 add_compile_options(-DRN_SERIALIZABLE_STATE=1)
+# Needed for sqlite3_column_table_name/origin_name, used to coerce boolean columns on read.
+add_compile_definitions(SQLITE_ENABLE_COLUMN_METADATA=1)
 
 # Define C++ library and add all sources
 add_library(${PACKAGE_NAME} SHARED
@@ -17,6 +19,7 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/database/SQLiteConnection.cpp
 	../cpp/database/DatabaseManager.cpp
 	../cpp/database/MigrationEngine.cpp
+	../cpp/database/SchemaRegistry.cpp
 	../cpp/query/QueryExecutor.cpp
 	../cpp/sync/SyncOrchestrator.cpp
 	../cpp/sync/SyncApplyGuard.cpp

--- a/cpp/database/DatabaseManager.cpp
+++ b/cpp/database/DatabaseManager.cpp
@@ -1,4 +1,5 @@
 #include "DatabaseManager.hpp"
+#include "SchemaRegistry.hpp"
 #include "../platform/platform.hpp"
 
 namespace margelo::nitro::salvedb {
@@ -7,6 +8,9 @@ void DatabaseManager::open(const std::string& dbName) {
   std::string dir  = platform::getDocumentsDirectory();
   std::string path = dir + "/" + dbName + ".db";
   _connection = std::make_shared<SQLiteConnection>(path);
+  // Boolean-column registrations are keyed by table name, not by db file — a stale
+  // entry from a previously-open database would otherwise silently leak into this one.
+  SchemaRegistry::shared().clear();
 }
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -1,8 +1,10 @@
 #include "MigrationEngine.hpp"
+#include "SchemaRegistry.hpp"
 
 #include <sstream>
 #include <algorithm>
 #include <stdexcept>
+#include <unordered_set>
 
 namespace margelo::nitro::salvedb {
 
@@ -310,6 +312,12 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
   }
 
   txn.commit();
+
+  std::unordered_set<std::string> booleanColumns;
+  for (auto& [colName, col] : schema.columns) {
+    if (col.type == "boolean") booleanColumns.insert(colName);
+  }
+  SchemaRegistry::shared().registerBooleanColumns(schema.name, std::move(booleanColumns));
 }
 
 // ── JSON parsing ──────────────────────────────────────────────────────────────

--- a/cpp/database/SQLiteConnection.cpp
+++ b/cpp/database/SQLiteConnection.cpp
@@ -1,4 +1,5 @@
 #include "SQLiteConnection.hpp"
+#include "SchemaRegistry.hpp"
 
 #include <NitroModules/ArrayBuffer.hpp>
 #include <stdexcept>
@@ -19,7 +20,19 @@ SQLiteConnection::SQLiteConnection(const std::string& path) {
   sqlite3_exec(_db, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr);
   sqlite3_exec(_db, "PRAGMA foreign_keys=ON;", nullptr, nullptr, nullptr);
   sqlite3_busy_timeout(_db, 5000);
+  sqlite3_extended_result_codes(_db, 1); // needed for errorPrefix() below
 }
+
+namespace {
+
+// Prefix is the only distinguishing signal that survives the JSI boundary (Nitro's
+// generated glue collapses thrown exceptions down to a plain message string).
+std::string errorPrefix(sqlite3* db) {
+  int primaryCode = sqlite3_extended_errcode(db) & 0xff;
+  return primaryCode == SQLITE_CONSTRAINT ? "SQLITE_CONSTRAINT: " : "SQLITE_ERROR: ";
+}
+
+} // namespace
 
 SQLiteConnection::~SQLiteConnection() {
   std::lock_guard<std::mutex> lock(_mutex);
@@ -50,7 +63,7 @@ sqlite3_stmt* SQLiteConnection::getOrPrepare(const std::string& sql) {
   sqlite3_stmt* stmt = nullptr;
   int rc = sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, nullptr);
   if (rc != SQLITE_OK) {
-    throw std::runtime_error(std::string("SQLite prepare error: ") + sqlite3_errmsg(_db) + " — SQL: " + sql);
+    throw std::runtime_error(errorPrefix(_db) + "SQLite prepare error: " + sqlite3_errmsg(_db) + " — SQL: " + sql);
   }
   _prepareCount++;
 
@@ -116,9 +129,18 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
         case SQLITE_NULL:
           row.emplace_back(nitro::NullType{});
           break;
-        case SQLITE_INTEGER:
-          row.emplace_back(static_cast<double>(sqlite3_column_int64(stmt, i)));
+        case SQLITE_INTEGER: {
+          // SQLite stores `boolean` columns as plain INTEGER 0/1; ask the registry which columns those are.
+          const char* table  = sqlite3_column_table_name(stmt, i);
+          const char* origin = sqlite3_column_origin_name(stmt, i);
+          int64_t intVal = sqlite3_column_int64(stmt, i);
+          if (table && origin && SchemaRegistry::shared().isBoolean(table, origin)) {
+            row.emplace_back(intVal != 0);
+          } else {
+            row.emplace_back(static_cast<double>(intVal));
+          }
           break;
+        }
         case SQLITE_FLOAT:
           row.emplace_back(sqlite3_column_double(stmt, i));
           break;
@@ -134,7 +156,8 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
           break;
         }
         default:
-          row.emplace_back(nitro::NullType{});
+          // sqlite3_column_type only ever returns the 5 cases above per SQLite's docs.
+          throw std::runtime_error("Unexpected SQLite column type");
       }
     }
     rows.push_back(std::move(row));
@@ -144,7 +167,7 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
   sqlite3_clear_bindings(stmt);
 
   if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
-    throw std::runtime_error(std::string("SQLite execute error: ") + sqlite3_errmsg(_db));
+    throw std::runtime_error(errorPrefix(_db) + "SQLite execute error: " + sqlite3_errmsg(_db));
   }
 
   return QueryResult{std::move(columns), std::move(rows)};

--- a/cpp/database/SQLiteConnection.cpp
+++ b/cpp/database/SQLiteConnection.cpp
@@ -20,16 +20,22 @@ SQLiteConnection::SQLiteConnection(const std::string& path) {
   sqlite3_exec(_db, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr);
   sqlite3_exec(_db, "PRAGMA foreign_keys=ON;", nullptr, nullptr, nullptr);
   sqlite3_busy_timeout(_db, 5000);
-  sqlite3_extended_result_codes(_db, 1); // needed for errorPrefix() below
+  sqlite3_extended_result_codes(_db, 1); // makes prepare/step/exec return extended codes directly
 }
 
 namespace {
 
 // Prefix is the only distinguishing signal that survives the JSI boundary (Nitro's
-// generated glue collapses thrown exceptions down to a plain message string).
-std::string errorPrefix(sqlite3* db) {
-  int primaryCode = sqlite3_extended_errcode(db) & 0xff;
-  return primaryCode == SQLITE_CONSTRAINT ? "SQLITE_CONSTRAINT: " : "SQLITE_ERROR: ";
+// generated glue collapses thrown exceptions down to a plain message string). Callers
+// must read the primary code immediately after the failing call, before any other
+// sqlite3 API touches the connection's error state.
+std::string errorPrefix(int primaryCode) {
+  switch (primaryCode) {
+    case SQLITE_CONSTRAINT: return "SQLITE_CONSTRAINT: ";
+    case SQLITE_BUSY:
+    case SQLITE_LOCKED:     return "SQLITE_BUSY: ";
+    default:                return "SQLITE_ERROR: ";
+  }
 }
 
 } // namespace
@@ -63,7 +69,8 @@ sqlite3_stmt* SQLiteConnection::getOrPrepare(const std::string& sql) {
   sqlite3_stmt* stmt = nullptr;
   int rc = sqlite3_prepare_v2(_db, sql.c_str(), -1, &stmt, nullptr);
   if (rc != SQLITE_OK) {
-    throw std::runtime_error(errorPrefix(_db) + "SQLite prepare error: " + sqlite3_errmsg(_db) + " — SQL: " + sql);
+    int primaryCode = sqlite3_extended_errcode(_db) & 0xff;
+    throw std::runtime_error(errorPrefix(primaryCode) + "SQLite prepare error: " + sqlite3_errmsg(_db) + " — SQL: " + sql);
   }
   _prepareCount++;
 
@@ -107,6 +114,7 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
 
   std::vector<std::string> columns;
   std::vector<std::vector<SqlValue>> rows;
+  std::vector<bool> isBoolCol;
   bool headerRead = false;
   int colCount = 0;
 
@@ -115,9 +123,16 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
     if (!headerRead) {
       colCount = sqlite3_column_count(stmt);
       columns.reserve(colCount);
+      isBoolCol.reserve(colCount);
       for (int i = 0; i < colCount; ++i) {
         const char* name = sqlite3_column_name(stmt, i);
         columns.emplace_back(name ? name : "");
+
+        // A column's origin table/name is fixed for the whole result set, so the
+        // (mutex-guarded) registry lookup only needs to happen once per column, not per cell.
+        const char* table  = sqlite3_column_table_name(stmt, i);
+        const char* origin = sqlite3_column_origin_name(stmt, i);
+        isBoolCol.push_back(table && origin && SchemaRegistry::shared().isBoolean(table, origin));
       }
       headerRead = true;
     }
@@ -130,11 +145,8 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
           row.emplace_back(nitro::NullType{});
           break;
         case SQLITE_INTEGER: {
-          // SQLite stores `boolean` columns as plain INTEGER 0/1; ask the registry which columns those are.
-          const char* table  = sqlite3_column_table_name(stmt, i);
-          const char* origin = sqlite3_column_origin_name(stmt, i);
           int64_t intVal = sqlite3_column_int64(stmt, i);
-          if (table && origin && SchemaRegistry::shared().isBoolean(table, origin)) {
+          if (isBoolCol[i]) {
             row.emplace_back(intVal != 0);
           } else {
             row.emplace_back(static_cast<double>(intVal));
@@ -163,11 +175,17 @@ QueryResult SQLiteConnection::execute(const std::string& sql, const std::vector<
     rows.push_back(std::move(row));
   }
 
+  // Capture the failure's error state before reset()/clear_bindings() run, so a future
+  // reordering of those calls can't silently make this read a stale/cleared code.
+  bool failed = rc != SQLITE_DONE && rc != SQLITE_ROW;
+  int primaryCode = failed ? (sqlite3_extended_errcode(_db) & 0xff) : 0;
+  std::string errMsg = failed ? sqlite3_errmsg(_db) : std::string{};
+
   sqlite3_reset(stmt);
   sqlite3_clear_bindings(stmt);
 
-  if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
-    throw std::runtime_error(errorPrefix(_db) + "SQLite execute error: " + sqlite3_errmsg(_db));
+  if (failed) {
+    throw std::runtime_error(errorPrefix(primaryCode) + "SQLite execute error: " + errMsg);
   }
 
   return QueryResult{std::move(columns), std::move(rows)};

--- a/cpp/database/SchemaRegistry.cpp
+++ b/cpp/database/SchemaRegistry.cpp
@@ -14,4 +14,9 @@ bool SchemaRegistry::isBoolean(const std::string& table, const std::string& colu
   return it->second.count(column) > 0;
 }
 
+void SchemaRegistry::clear() {
+  std::lock_guard<std::mutex> lock(_mutex);
+  _booleanColumns.clear();
+}
+
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/SchemaRegistry.cpp
+++ b/cpp/database/SchemaRegistry.cpp
@@ -1,0 +1,17 @@
+#include "SchemaRegistry.hpp"
+
+namespace margelo::nitro::salvedb {
+
+void SchemaRegistry::registerBooleanColumns(const std::string& table, std::unordered_set<std::string> columns) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  _booleanColumns[table] = std::move(columns);
+}
+
+bool SchemaRegistry::isBoolean(const std::string& table, const std::string& column) const {
+  std::lock_guard<std::mutex> lock(_mutex);
+  auto it = _booleanColumns.find(table);
+  if (it == _booleanColumns.end()) return false;
+  return it->second.count(column) > 0;
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/database/SchemaRegistry.hpp
+++ b/cpp/database/SchemaRegistry.hpp
@@ -20,6 +20,11 @@ public:
   void registerBooleanColumns(const std::string& table, std::unordered_set<std::string> columns);
   bool isBoolean(const std::string& table, const std::string& column) const;
 
+  // Discards all registrations. Must run whenever the underlying SQLite connection
+  // changes (DatabaseManager::open()) — entries are keyed by table name only, not by
+  // db file, so stale entries from a previously-open database would otherwise leak in.
+  void clear();
+
 private:
   SchemaRegistry() = default;
 

--- a/cpp/database/SchemaRegistry.hpp
+++ b/cpp/database/SchemaRegistry.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace margelo::nitro::salvedb {
+
+// Tracks which registered columns are declared as `boolean` in the TS schema,
+// so SQLiteConnection::execute can coerce SQLite's 0/1 INTEGER storage back
+// to a JS bool on read — SQLite itself has no native boolean column type.
+class SchemaRegistry {
+public:
+  static SchemaRegistry& shared() {
+    static SchemaRegistry instance;
+    return instance;
+  }
+
+  void registerBooleanColumns(const std::string& table, std::unordered_set<std::string> columns);
+  bool isBoolean(const std::string& table, const std::string& column) const;
+
+private:
+  SchemaRegistry() = default;
+
+  mutable std::mutex _mutex;
+  std::unordered_map<std::string, std::unordered_set<std::string>> _booleanColumns;
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/database/SQLiteConnection.cpp"
   "${PROJECT_CPP_DIR}/database/DatabaseManager.cpp"
   "${PROJECT_CPP_DIR}/database/MigrationEngine.cpp"
+  "${PROJECT_CPP_DIR}/database/SchemaRegistry.cpp"
   "${PROJECT_CPP_DIR}/query/QueryExecutor.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncOrchestrator.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncApplyGuard.cpp"
@@ -144,6 +145,7 @@ target_include_directories(salvedb_tests PRIVATE
   "${PROJECT_CPP_DIR}/third_party/sqlite3"
   "${GENERATED_CPP_DIR}"
 )
+target_compile_definitions(salvedb_tests PRIVATE SQLITE_ENABLE_COLUMN_METADATA=1)
 target_link_libraries(salvedb_tests PRIVATE Catch2::Catch2WithMain)
 target_link_options(salvedb_tests PRIVATE "-F${HERMES_FRAMEWORKS_DIR}" "-framework" "hermesvm")
 set_target_properties(salvedb_tests PROPERTIES

--- a/cpp/tests/database/HybridSalveDatabaseTests.cpp
+++ b/cpp/tests/database/HybridSalveDatabaseTests.cpp
@@ -51,7 +51,7 @@ TEST_CASE("execute() round-trips insert/select/update/delete across column types
   // MigrationEngine stores columns in a std::map, so CREATE TABLE emits them
   // alphabetically regardless of the schema's declaration order.
   auto selected = harness.run("db.execute('SELECT * FROM items WHERE id = 1', [])");
-  REQUIRE(selected == R"({"columns":["active","createdAt","id","label","price"],"rows":[[1,1700000000000,1,"widget",9.99]]})");
+  REQUIRE(selected == R"({"columns":["active","createdAt","id","label","price"],"rows":[[true,1700000000000,1,"widget",9.99]]})");
 
   harness.run("db.execute('UPDATE items SET label = ? WHERE id = 1', ['widget-updated'])");
   auto updated = harness.run("db.execute('SELECT label FROM items WHERE id = 1', [])");

--- a/cpp/tests/query/QueryExecutorTests.cpp
+++ b/cpp/tests/query/QueryExecutorTests.cpp
@@ -1,0 +1,79 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include "../support/HybridDatabaseHarness.hpp"
+
+using margelo::nitro::salvedb::tests::HybridDatabaseHarness;
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+std::string configureExpr(const std::string& name) {
+  return "db.configure({ name: '" + name + "' })";
+}
+
+void createDb(HybridDatabaseHarness& harness, const std::string& name) {
+  harness.run("(() => { globalThis.db = globalThis.NitroModulesProxy.createHybridObject('SalveDatabase'); return true; })()");
+  harness.run(configureExpr(uniqueDbName(name)));
+}
+
+} // namespace
+
+TEST_CASE("execute() coerces boolean columns to JS true/false, not 0/1", "[query][types]") {
+  HybridDatabaseHarness harness;
+  createDb(harness, "bool_coercion");
+
+  harness.run(R"(
+    db.registerSchema(JSON.stringify({
+      name: 'flags', version: 1, primaryKey: 'id',
+      columns: { id: { type: 'integer' }, enabled: { type: 'boolean' } }
+    }))
+  )");
+
+  harness.run("db.execute('INSERT INTO flags (id, enabled) VALUES (?, ?), (?, ?)', [1, true, 2, false])");
+
+  auto selected = harness.run("db.execute('SELECT id, enabled FROM flags ORDER BY id', [])");
+  REQUIRE(selected == R"({"columns":["id","enabled"],"rows":[[1,true],[2,false]]})");
+}
+
+TEST_CASE("execute() propagates a syntax error as a catchable, distinguishable JS error", "[query][errors]") {
+  HybridDatabaseHarness harness;
+  createDb(harness, "syntax_error");
+
+  CHECK_THROWS_WITH(harness.run("db.execute('SELCT 1', [])"), ContainsSubstring("SQLITE_ERROR:"));
+}
+
+TEST_CASE("execute() propagates a constraint violation distinguishable from a syntax error", "[query][errors]") {
+  HybridDatabaseHarness harness;
+  createDb(harness, "constraint_error");
+  harness.run("db.execute('CREATE TABLE uniq (id INTEGER PRIMARY KEY, code TEXT UNIQUE)', [])");
+  harness.run("db.execute('INSERT INTO uniq (id, code) VALUES (1, ?)', ['A'])");
+
+  CHECK_THROWS_WITH(
+    harness.run("db.execute('INSERT INTO uniq (id, code) VALUES (2, ?)', ['A'])"),
+    ContainsSubstring("SQLITE_CONSTRAINT:"));
+}
+
+TEST_CASE("execute() writes through db.execute fire sync triggers into sync_queue", "[query][sync]") {
+  HybridDatabaseHarness harness;
+  createDb(harness, "trigger_via_bridge");
+
+  harness.run(R"(
+    db.registerSchema(JSON.stringify({
+      name: 'notes', version: 1, primaryKey: 'id',
+      columns: { id: { type: 'integer' }, body: { type: 'text' } },
+      sync: { enabled: true }
+    }))
+  )");
+
+  harness.run("db.execute('INSERT INTO notes (id, body) VALUES (1, ?)', ['hello'])");
+  harness.run("db.execute('UPDATE notes SET body = ? WHERE id = 1', ['updated'])");
+  harness.run("db.execute('DELETE FROM notes WHERE id = 1', [])");
+
+  auto queued = harness.run("db.execute('SELECT operation, entity FROM sync_queue ORDER BY id', [])");
+  REQUIRE(queued == R"({"columns":["operation","entity"],"rows":[["insert","notes"],["update","notes"],["delete","notes"]]})");
+}

--- a/cpp/tests/query/QueryExecutorTests.cpp
+++ b/cpp/tests/query/QueryExecutorTests.cpp
@@ -40,6 +40,60 @@ TEST_CASE("execute() coerces boolean columns to JS true/false, not 0/1", "[query
   REQUIRE(selected == R"({"columns":["id","enabled"],"rows":[[1,true],[2,false]]})");
 }
 
+TEST_CASE("execute() scopes boolean coercion by table, not just column name", "[query][types]") {
+  HybridDatabaseHarness harness;
+  createDb(harness, "bool_table_scope");
+
+  harness.run(R"(
+    db.registerSchema(JSON.stringify({
+      name: 'switches_bool', version: 1, primaryKey: 'id',
+      columns: { id: { type: 'integer' }, flag: { type: 'boolean' } }
+    }))
+  )");
+  // Same column name ('flag'), never registered as boolean — must stay a plain number.
+  harness.run("db.execute('CREATE TABLE switches_int (id INTEGER PRIMARY KEY, flag INTEGER)', [])");
+
+  harness.run("db.execute('INSERT INTO switches_bool (id, flag) VALUES (1, ?)', [true])");
+  harness.run("db.execute('INSERT INTO switches_int (id, flag) VALUES (1, ?)', [5])");
+
+  auto boolResult = harness.run("db.execute('SELECT flag FROM switches_bool WHERE id = 1', [])");
+  REQUIRE(boolResult == R"({"columns":["flag"],"rows":[[true]]})");
+
+  auto intResult = harness.run("db.execute('SELECT flag FROM switches_int WHERE id = 1', [])");
+  REQUIRE(intResult == R"({"columns":["flag"],"rows":[[5]]})");
+}
+
+TEST_CASE("execute() boolean coercion follows column origin, not aliasing", "[query][types]") {
+  HybridDatabaseHarness harness;
+  createDb(harness, "bool_origin_boundary");
+
+  harness.run(R"(
+    db.registerSchema(JSON.stringify({
+      name: 'toggles', version: 1, primaryKey: 'id',
+      columns: { id: { type: 'integer' }, enabled: { type: 'boolean' } }
+    }))
+  )");
+  harness.run("db.execute('INSERT INTO toggles (id, enabled) VALUES (1, ?)', [true])");
+
+  SECTION("plain alias still resolves to the origin column") {
+    auto aliased = harness.run("db.execute('SELECT enabled AS e FROM toggles WHERE id = 1', [])");
+    REQUIRE(aliased == R"({"columns":["e"],"rows":[[true]]})");
+  }
+
+  SECTION("a computed expression has no column origin, falls back to a plain number") {
+    auto computed = harness.run("db.execute('SELECT enabled + 0 AS e FROM toggles WHERE id = 1', [])");
+    REQUIRE(computed == R"({"columns":["e"],"rows":[[1]]})");
+  }
+
+  SECTION("boolean coercion still applies to a column read through a JOIN") {
+    harness.run("db.execute('CREATE TABLE labels (toggle_id INTEGER, label TEXT)', [])");
+    harness.run("db.execute('INSERT INTO labels (toggle_id, label) VALUES (1, ?)', ['x'])");
+    auto joined = harness.run(
+      "db.execute('SELECT toggles.enabled FROM toggles JOIN labels ON labels.toggle_id = toggles.id', [])");
+    REQUIRE(joined == R"({"columns":["enabled"],"rows":[[true]]})");
+  }
+}
+
 TEST_CASE("execute() propagates a syntax error as a catchable, distinguishable JS error", "[query][errors]") {
   HybridDatabaseHarness harness;
   createDb(harness, "syntax_error");

--- a/cpp/tests/query/README.md
+++ b/cpp/tests/query/README.md
@@ -1,5 +1,5 @@
 Tests for `cpp/query/*` (currently `QueryExecutor`) go here, mirroring the
-main `cpp/` layout. Nothing here yet — `QueryExecutor`'s behavior is covered
-end-to-end through `cpp/tests/database/HybridSalveDatabaseTests.cpp` for now.
-Add a dedicated file here if/when it needs coverage that doesn't go through
-the full `HybridSalveDatabase` JSI bridge.
+main `cpp/` layout. `QueryExecutorTests.cpp` covers behavior specific to this
+layer (boolean coercion, distinguishable SQL errors, triggers via `db.execute`)
+through the real `HybridSalveDatabase` JSI bridge; happy-path SELECT/INSERT/
+UPDATE/DELETE round-tripping stays in `cpp/tests/database/HybridSalveDatabaseTests.cpp`.


### PR DESCRIPTION
## Summary
- Closes the 2 previously-unmet acceptance criteria of TASK-007 (issue #8): `boolean` columns now round-trip as JS `true`/`false` instead of `1`/`0`, and constraint-violation errors are now distinguishable from syntax errors via a `SQLITE_CONSTRAINT:`/`SQLITE_ERROR:`/`SQLITE_BUSY:` message prefix (the only signal that survives Nitro's generated exception-to-JSError wrapping).
- New `SchemaRegistry` (in-memory, keyed by table name) tracks which columns are `boolean`, populated from `MigrationEngine::registerSchema` and consulted by `SQLiteConnection::execute` via `sqlite3_column_table_name`/`origin_name` (requires `SQLITE_ENABLE_COLUMN_METADATA`, enabled in all 3 build configs: podspec, Android CMake, tests CMake).
- Follow-up hardening from an Opus-assisted review round of the first commit: error-code capture moved before `reset()`/`clear_bindings()` to avoid ever reading a stale code, the boolean-registry lookup hoisted from per-cell to per-column, and `SchemaRegistry::clear()` wired into `DatabaseManager::open()` so a stale registration can't leak across databases.
- New `cpp/tests/query/QueryExecutorTests.cpp` (previously empty) covers boolean round-trip, table-scoped coercion (two tables sharing a column name, one boolean one not), the `origin_name` fallback boundary (alias/expression/JOIN), syntax vs. constraint error distinguishability, and trigger firing through the real `db.execute` JSI bridge — all exercised through the real HybridSalveDatabase bridge per this repo's native-tests rule.
- Fixed a stale assertion in `HybridSalveDatabaseTests.cpp` that had codified the old (wrong) `1`/`0` boolean behavior.

Out of scope, tracked separately in #47: large-integer precision loss (`sqlite3_column_int64` → `double`, unsafe above 2^53) — a broader `SqlValue` contract change, not something TASK-007's criteria asked for.

## Test plan
- [x] `npm run test:native` — 97 assertions across 29 test cases, all passing.
- [x] Manually traced boolean coercion and error-prefix logic against SQLite's own source (`cpp/third_party/sqlite3/sqlite3.c`) to rule out stale-error-code and lock-ordering concerns raised in review.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean database columns now consistently return `true` or `false` instead of numeric values, including when queried through aliases or joins.
  * Boolean handling is correctly scoped to each table and database connection.
  * SQL errors now provide clearer, distinguishable error information for syntax and constraint failures.
  * Database changes through `execute()` continue to trigger the expected synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->