### PR TITLE
fix(query): prefix execLocked errors, fix CMake version mismatch

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -7,8 +7,6 @@ set (CMAKE_CXX_STANDARD 20)
 
 # Enable Raw Props parsing in react-native (for Nitro Views)
 add_compile_options(-DRN_SERIALIZABLE_STATE=1)
-# Needed for sqlite3_column_table_name/origin_name, used to coerce boolean columns on read.
-add_compile_definitions(SQLITE_ENABLE_COLUMN_METADATA=1)
 
 # Define C++ library and add all sources
 add_library(${PACKAGE_NAME} SHARED
@@ -24,6 +22,11 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/sync/SyncOrchestrator.cpp
 	../cpp/sync/SyncApplyGuard.cpp
 )
+
+# Needed for sqlite3_column_table_name/origin_name, used to coerce boolean columns on read.
+# target_compile_definitions (not add_compile_definitions, which needs CMake >= 3.12)
+# keeps this working under the cmake_minimum_required(3.9.0) declared above.
+target_compile_definitions(${PACKAGE_NAME} PRIVATE SQLITE_ENABLE_COLUMN_METADATA=1)
 
 # Add Nitrogen specs :)
 include(${CMAKE_SOURCE_DIR}/../nitrogen/generated/android/SalveDb+autolinking.cmake)

--- a/cpp/database/SQLiteConnection.cpp
+++ b/cpp/database/SQLiteConnection.cpp
@@ -224,9 +224,10 @@ void SQLiteConnection::execLocked(const std::string& sql) {
   char* errMsg = nullptr;
   int rc = sqlite3_exec(_db, sql.c_str(), nullptr, nullptr, &errMsg);
   if (rc != SQLITE_OK) {
+    int primaryCode = sqlite3_extended_errcode(_db) & 0xff;
     std::string err = errMsg ? errMsg : "unknown error";
     sqlite3_free(errMsg);
-    throw std::runtime_error("SQLite exec error: " + err + " — SQL: " + sql);
+    throw std::runtime_error(errorPrefix(primaryCode) + "SQLite exec error: " + err + " — SQL: " + sql);
   }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #48 (TASK-007 / issue #8, already merged), addressing 2 findings from CodeRabbit's review on that PR that landed after merge:

- **`execLocked()` errors bypassed the new error-prefix classification.** `getOrPrepare`/`execute` prefix thrown errors with `SQLITE_CONSTRAINT:`/`SQLITE_BUSY:`/`SQLITE_ERROR:`, but `execLocked` (which backs `exec()`, `beginTransaction()`, `commit()`, `rollback()`) still threw an unprefixed message. A `COMMIT` can surface a deferred-FK constraint failure or lock contention, so this path needed the same contract.
- **`android/CMakeLists.txt` mixed `add_compile_definitions()` (requires CMake ≥ 3.12) with `cmake_minimum_required(VERSION 3.9.0)`.** Switched to `target_compile_definitions()`, which works down to the declared minimum and matches the pattern already used in `cpp/tests/CMakeLists.txt`.

Refs #8

## Test plan
- [x] `npm run test:native` — 97 assertions, 29 test cases, all passing (branch rebased clean on top of the merged `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQLite error messages by including the specific primary error category, making database failures easier to understand and troubleshoot.
  - Updated native SQLite configuration to apply required metadata support consistently while avoiding unintended effects on other build targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->