### PR TITLE
feat(expression): TASK-008 declarative expression interpreter

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -21,6 +21,9 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/query/QueryExecutor.cpp
 	../cpp/sync/SyncOrchestrator.cpp
 	../cpp/sync/SyncApplyGuard.cpp
+	../cpp/sync/SyncQueueReader.cpp
+	../cpp/expression/RequestExpressionEvaluator.cpp
+	../cpp/expression/JsonPathExtractor.cpp
 )
 
 # Needed for sqlite3_column_table_name/origin_name, used to coerce boolean columns on read.
@@ -39,6 +42,7 @@ include_directories(
         "../cpp/platform"
         "../cpp/query"
         "../cpp/sync"
+        "../cpp/expression"
         "../cpp/third_party/sqlite3"
 )
 

--- a/cpp/database/json_parser.hpp
+++ b/cpp/database/json_parser.hpp
@@ -8,7 +8,10 @@
 #include <optional>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <functional>
+#include <iomanip>
+#include <limits>
 #include <sstream>
 
 namespace margelo::nitro::salvedb::json {
@@ -212,7 +215,7 @@ inline void stringifyString(const std::string& s, std::ostringstream& out) {
       default:
         if (static_cast<unsigned char>(c) < 0x20) {
           char buf[7];
-          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+          std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned int>(static_cast<unsigned char>(c)));
           out << buf;
         } else {
           out << c;
@@ -223,11 +226,13 @@ inline void stringifyString(const std::string& s, std::ostringstream& out) {
 }
 
 inline void stringifyNumber(double d, std::ostringstream& out) {
-  if (std::isfinite(d) && d == std::floor(d) &&
-      std::abs(d) < 1e15) {
+  if (!std::isfinite(d)) {
+    throw std::runtime_error("json::stringify: cannot serialize non-finite number (NaN/Infinity)");
+  }
+  if (d == std::floor(d) && std::abs(d) < 1e15) {
     out << static_cast<long long>(d);
   } else {
-    out << d;
+    out << std::setprecision(std::numeric_limits<double>::max_digits10) << d;
   }
 }
 

--- a/cpp/database/json_parser.hpp
+++ b/cpp/database/json_parser.hpp
@@ -7,7 +7,9 @@
 #include <stdexcept>
 #include <optional>
 #include <cctype>
+#include <cmath>
 #include <functional>
+#include <sstream>
 
 namespace margelo::nitro::salvedb::json {
 
@@ -192,6 +194,82 @@ public:
 
 inline Value parse(const std::string& json) {
   return Parser(json).parse();
+}
+
+namespace detail {
+
+inline void stringifyString(const std::string& s, std::ostringstream& out) {
+  out << '"';
+  for (char c : s) {
+    switch (c) {
+      case '"':  out << "\\\""; break;
+      case '\\': out << "\\\\"; break;
+      case '\n': out << "\\n";  break;
+      case '\r': out << "\\r";  break;
+      case '\t': out << "\\t";  break;
+      case '\b': out << "\\b";  break;
+      case '\f': out << "\\f";  break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buf[7];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+          out << buf;
+        } else {
+          out << c;
+        }
+    }
+  }
+  out << '"';
+}
+
+inline void stringifyNumber(double d, std::ostringstream& out) {
+  if (std::isfinite(d) && d == std::floor(d) &&
+      std::abs(d) < 1e15) {
+    out << static_cast<long long>(d);
+  } else {
+    out << d;
+  }
+}
+
+inline void stringifyValue(const Value& v, std::ostringstream& out) {
+  if (v.isNull()) {
+    out << "null";
+  } else if (v.isBool()) {
+    out << (v.asBool() ? "true" : "false");
+  } else if (v.isNumber()) {
+    stringifyNumber(v.asNumber(), out);
+  } else if (v.isString()) {
+    stringifyString(v.asString(), out);
+  } else if (v.isArray()) {
+    out << '[';
+    const Array& arr = v.asArray();
+    for (size_t i = 0; i < arr.size(); ++i) {
+      if (i > 0) out << ',';
+      stringifyValue(arr[i], out);
+    }
+    out << ']';
+  } else if (v.isObject()) {
+    out << '{';
+    const Object& obj = v.asObject();
+    bool first = true;
+    for (const auto& [key, value] : obj) {
+      if (!first) out << ',';
+      first = false;
+      stringifyString(key, out);
+      out << ':';
+      stringifyValue(value, out);
+    }
+    out << '}';
+  }
+}
+
+} // namespace detail
+
+// Object key order follows std::map's lexicographic order, not insertion order.
+inline std::string stringify(const Value& v) {
+  std::ostringstream out;
+  detail::stringifyValue(v, out);
+  return out.str();
 }
 
 } // namespace margelo::nitro::salvedb::json

--- a/cpp/expression/JsonPathExtractor.cpp
+++ b/cpp/expression/JsonPathExtractor.cpp
@@ -1,0 +1,55 @@
+#include "JsonPathExtractor.hpp"
+#include <stdexcept>
+#include <vector>
+
+namespace margelo::nitro::salvedb {
+
+namespace {
+
+std::vector<std::string> splitSegments(const std::string& rest) {
+  std::vector<std::string> segments;
+  size_t start = 0;
+  while (start < rest.size()) {
+    size_t dot = rest.find('.', start);
+    size_t end = (dot == std::string::npos) ? rest.size() : dot;
+    if (end == start) {
+      throw std::runtime_error("ExpressionInterpreter: malformed JsonPath \"" + rest + "\"");
+    }
+    segments.push_back(rest.substr(start, end - start));
+    start = (dot == std::string::npos) ? rest.size() : dot + 1;
+  }
+  if (!rest.empty() && rest.back() == '.') {
+    throw std::runtime_error("ExpressionInterpreter: malformed JsonPath, trailing \".\"");
+  }
+  return segments;
+}
+
+} // namespace
+
+std::optional<json::Value> JsonPathExtractor::extract(const json::Value& root, const std::string& path) {
+  if (path.empty() || path[0] != '$') {
+    throw std::runtime_error("ExpressionInterpreter: JsonPath must start with \"$\", got \"" + path + "\"");
+  }
+
+  std::string rest = path.substr(1);
+  if (rest.empty()) {
+    return root;
+  }
+  if (rest[0] != '.') {
+    throw std::runtime_error("ExpressionInterpreter: malformed JsonPath \"" + path + "\"");
+  }
+
+  auto segments = splitSegments(rest.substr(1));
+
+  const json::Value* current = &root;
+  for (const auto& segment : segments) {
+    auto next = current->get(segment);
+    if (!next) {
+      return std::nullopt;
+    }
+    current = &next->get();
+  }
+  return *current;
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/expression/JsonPathExtractor.hpp
+++ b/cpp/expression/JsonPathExtractor.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../database/json_parser.hpp"
+#include <optional>
+#include <string>
+
+namespace margelo::nitro::salvedb {
+
+// Plain C++ collaborator (not a HybridObject) — extracts a value from a
+// response json::Value via the MVP JsonPath subset ($.a.b, dot-separated
+// keys only, no array indexing/wildcards).
+class JsonPathExtractor {
+public:
+  // std::nullopt means the path is absent; an engaged optional holding a
+  // JSON null Value means the path resolved to a literal null.
+  static std::optional<json::Value> extract(const json::Value& root, const std::string& path);
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/expression/RequestExpressionEvaluator.cpp
+++ b/cpp/expression/RequestExpressionEvaluator.cpp
@@ -1,0 +1,81 @@
+#include "RequestExpressionEvaluator.hpp"
+#include <stdexcept>
+#include <unordered_set>
+
+namespace margelo::nitro::salvedb {
+
+namespace {
+
+const std::unordered_set<std::string> kSupportedRefs = {"cursor", "operations", "pageSize"};
+const std::unordered_set<std::string> kUnimplementedRefs = {
+  "changes", "deviceId", "platform", "timestamp", "userId"
+};
+
+json::Value evaluateRef(const json::Value& node, const RequestExpressionEvaluator::VariableResolver& resolver) {
+  const json::Value& refValue = node["$ref"];
+  if (!refValue.isString()) {
+    throw std::runtime_error("ExpressionInterpreter: $ref must be a string");
+  }
+  const std::string& refName = refValue.asString();
+
+  if (kUnimplementedRefs.count(refName) > 0) {
+    throw std::runtime_error("ExpressionInterpreter: $ref \"" + refName + "\" is not implemented in the MVP");
+  }
+  if (kSupportedRefs.count(refName) == 0) {
+    throw std::runtime_error("ExpressionInterpreter: unknown $ref \"" + refName + "\"");
+  }
+  return resolver(refName);
+}
+
+json::Value evaluateObject(const json::Value& node, const RequestExpressionEvaluator::VariableResolver& resolver) {
+  const json::Value& inner = node["object"];
+  if (!inner.isObject()) {
+    throw std::runtime_error("ExpressionInterpreter: ObjectExpression's \"object\" must be an object");
+  }
+  json::Object result;
+  for (const auto& [key, value] : inner.asObject()) {
+    result[key] = RequestExpressionEvaluator::evaluate(value, resolver);
+  }
+  return json::Value(std::move(result));
+}
+
+json::Value evaluateArray(const json::Value& node, const RequestExpressionEvaluator::VariableResolver& resolver) {
+  const json::Value& inner = node["items"];
+  if (!inner.isArray()) {
+    throw std::runtime_error("ExpressionInterpreter: ArrayExpression's \"items\" must be an array");
+  }
+  json::Array result;
+  result.reserve(inner.asArray().size());
+  for (const auto& item : inner.asArray()) {
+    result.push_back(RequestExpressionEvaluator::evaluate(item, resolver));
+  }
+  return json::Value(std::move(result));
+}
+
+} // namespace
+
+json::Value RequestExpressionEvaluator::evaluate(const json::Value& expression, const VariableResolver& resolver) {
+  if (!expression.isObject()) {
+    throw std::runtime_error("ExpressionInterpreter: expression node must be an object");
+  }
+
+  const bool hasRef    = expression.has("$ref");
+  const bool hasValue  = expression.has("value");
+  const bool hasObject = expression.has("object");
+  const bool hasItems  = expression.has("items");
+  const int matches = hasRef + hasValue + hasObject + hasItems;
+
+  if (matches != 1) {
+    throw std::runtime_error(
+      "ExpressionInterpreter: expression node must have exactly one of "
+      "\"$ref\", \"value\", \"object\", \"items\" (found " + std::to_string(matches) + ")"
+    );
+  }
+
+  if (hasRef)    return evaluateRef(expression, resolver);
+  if (hasValue)  return expression["value"];
+  if (hasObject) return evaluateObject(expression, resolver);
+  return evaluateArray(expression, resolver);
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/expression/RequestExpressionEvaluator.hpp
+++ b/cpp/expression/RequestExpressionEvaluator.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "../database/json_parser.hpp"
+#include <functional>
+#include <string>
+
+namespace margelo::nitro::salvedb {
+
+// Plain C++ collaborator (not a HybridObject) — evaluates a parsed
+// RequestExpression tree (json::Value) into a request body json::Value.
+class RequestExpressionEvaluator {
+public:
+  using VariableResolver = std::function<json::Value(const std::string& refName)>;
+
+  static json::Value evaluate(const json::Value& expression, const VariableResolver& resolver);
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncQueueReader.cpp
+++ b/cpp/sync/SyncQueueReader.cpp
@@ -1,4 +1,5 @@
 #include "SyncQueueReader.hpp"
+#include <stdexcept>
 
 namespace margelo::nitro::salvedb {
 
@@ -6,6 +7,10 @@ SyncQueueReader::SyncQueueReader(std::shared_ptr<SQLiteConnection> conn)
   : _conn(std::move(conn)) {}
 
 json::Array SyncQueueReader::readOperations(int limit) {
+  if (limit < 0) {
+    throw std::runtime_error("SyncQueueReader: limit must be >= 0, got " + std::to_string(limit));
+  }
+
   auto result = _conn->execute(
     "SELECT operation, entity, entity_id, payload, updated_at "
     "FROM sync_queue ORDER BY id ASC LIMIT ?",

--- a/cpp/sync/SyncQueueReader.cpp
+++ b/cpp/sync/SyncQueueReader.cpp
@@ -1,0 +1,31 @@
+#include "SyncQueueReader.hpp"
+
+namespace margelo::nitro::salvedb {
+
+SyncQueueReader::SyncQueueReader(std::shared_ptr<SQLiteConnection> conn)
+  : _conn(std::move(conn)) {}
+
+json::Array SyncQueueReader::readOperations(int limit) {
+  auto result = _conn->execute(
+    "SELECT operation, entity, entity_id, payload, updated_at "
+    "FROM sync_queue ORDER BY id ASC LIMIT ?",
+    { static_cast<double>(limit) }
+  );
+
+  json::Array operations;
+  operations.reserve(result.rows.size());
+
+  for (const auto& row : result.rows) {
+    json::Object op;
+    op["operation"]  = json::Value(std::get<std::string>(row[0]));
+    op["entity"]     = json::Value(std::get<std::string>(row[1]));
+    op["primaryKey"] = json::Value(std::get<std::string>(row[2]));
+    op["payload"]    = json::parse(std::get<std::string>(row[3]));
+    op["updatedAt"]  = json::Value(std::get<double>(row[4]));
+    operations.emplace_back(std::move(op));
+  }
+
+  return operations;
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncQueueReader.hpp
+++ b/cpp/sync/SyncQueueReader.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../database/SQLiteConnection.hpp"
+#include "../database/json_parser.hpp"
+#include <memory>
+
+namespace margelo::nitro::salvedb {
+
+// Plain C++ collaborator (not a HybridObject) — read-only access to sync_queue.
+class SyncQueueReader {
+public:
+  explicit SyncQueueReader(std::shared_ptr<SQLiteConnection> conn);
+
+  // FIFO, up to `limit` rows, serialized to the TS `ISyncOperation` shape.
+  json::Array readOperations(int limit);
+
+private:
+  std::shared_ptr<SQLiteConnection> _conn;
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -115,6 +115,9 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/query/QueryExecutor.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncOrchestrator.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncApplyGuard.cpp"
+  "${PROJECT_CPP_DIR}/sync/SyncQueueReader.cpp"
+  "${PROJECT_CPP_DIR}/expression/RequestExpressionEvaluator.cpp"
+  "${PROJECT_CPP_DIR}/expression/JsonPathExtractor.cpp"
   "${PROJECT_CPP_DIR}/third_party/sqlite3/sqlite3.c"
   "${GENERATED_CPP_DIR}/HybridSalveDatabaseSpec.cpp"
 )
@@ -126,6 +129,7 @@ file(GLOB_RECURSE TEST_SOURCES
   "${CMAKE_SOURCE_DIR}/database/*.cpp"
   "${CMAKE_SOURCE_DIR}/query/*.cpp"
   "${CMAKE_SOURCE_DIR}/sync/*.cpp"
+  "${CMAKE_SOURCE_DIR}/expression/*.cpp"
 )
 
 # ── Real test suite: Catch2 + HybridSalveDatabase through real JSI ─────────
@@ -142,6 +146,7 @@ target_include_directories(salvedb_tests PRIVATE
   "${PROJECT_CPP_DIR}/platform"
   "${PROJECT_CPP_DIR}/query"
   "${PROJECT_CPP_DIR}/sync"
+  "${PROJECT_CPP_DIR}/expression"
   "${PROJECT_CPP_DIR}/third_party/sqlite3"
   "${GENERATED_CPP_DIR}"
 )

--- a/cpp/tests/database/JsonParserTests.cpp
+++ b/cpp/tests/database/JsonParserTests.cpp
@@ -1,0 +1,30 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/json_parser.hpp"
+#include <limits>
+
+using namespace margelo::nitro::salvedb;
+
+TEST_CASE("stringify preserves fractional precision", "[json][stringify]") {
+  double value = 1.0 / 3.0;
+  auto serialized = json::stringify(json::Value(value));
+  auto roundTripped = json::parse(serialized);
+  REQUIRE(roundTripped.asNumber() == value);
+}
+
+TEST_CASE("stringify rejects NaN and Infinity", "[json][stringify]") {
+  double nan = std::numeric_limits<double>::quiet_NaN();
+  double inf = std::numeric_limits<double>::infinity();
+  REQUIRE_THROWS_AS(json::stringify(json::Value(nan)), std::runtime_error);
+  REQUIRE_THROWS_AS(json::stringify(json::Value(inf)), std::runtime_error);
+}
+
+TEST_CASE("stringify still prints integral doubles without a decimal point", "[json][stringify]") {
+  REQUIRE(json::stringify(json::Value(42.0)) == "42");
+}
+
+TEST_CASE("stringify escapes control characters as \\u00XX", "[json][stringify]") {
+  std::string withControlChar = "a";
+  withControlChar += '\x01';
+  withControlChar += "b";
+  REQUIRE(json::stringify(json::Value(withControlChar)) == "\"a\\u0001b\"");
+}

--- a/cpp/tests/expression/JsonPathExtractorTests.cpp
+++ b/cpp/tests/expression/JsonPathExtractorTests.cpp
@@ -1,0 +1,63 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../expression/JsonPathExtractor.hpp"
+
+using namespace margelo::nitro::salvedb;
+
+TEST_CASE("extracts a top-level field", "[expression][JsonPathExtractor]") {
+  auto response = json::parse(R"({"cursor": "abc123", "hasMore": true})");
+
+  auto cursor = JsonPathExtractor::extract(response, "$.cursor");
+  REQUIRE(cursor.has_value());
+  REQUIRE(cursor->asString() == "abc123");
+
+  auto hasMore = JsonPathExtractor::extract(response, "$.hasMore");
+  REQUIRE(hasMore.has_value());
+  REQUIRE(hasMore->asBool() == true);
+}
+
+TEST_CASE("extracts a nested field", "[expression][JsonPathExtractor]") {
+  auto response = json::parse(R"({"data": {"items": [1, 2, 3]}})");
+
+  auto items = JsonPathExtractor::extract(response, "$.data.items");
+  REQUIRE(items.has_value());
+  REQUIRE(items->asArray().size() == 3);
+}
+
+TEST_CASE("returns nullopt for an absent path", "[expression][JsonPathExtractor]") {
+  auto response = json::parse(R"({"cursor": "abc123"})");
+
+  auto missing = JsonPathExtractor::extract(response, "$.missing");
+  REQUIRE_FALSE(missing.has_value());
+
+  auto missingNested = JsonPathExtractor::extract(response, "$.data.items");
+  REQUIRE_FALSE(missingNested.has_value());
+}
+
+TEST_CASE("distinguishes an absent path from a path resolving to null", "[expression][JsonPathExtractor]") {
+  auto response = json::parse(R"({"a": null})");
+
+  auto present = JsonPathExtractor::extract(response, "$.a");
+  REQUIRE(present.has_value());
+  REQUIRE(present->isNull());
+
+  auto absent = JsonPathExtractor::extract(response, "$.b");
+  REQUIRE_FALSE(absent.has_value());
+}
+
+TEST_CASE("$ alone returns the root value", "[expression][JsonPathExtractor]") {
+  auto response = json::parse(R"({"cursor": "abc123"})");
+
+  auto root = JsonPathExtractor::extract(response, "$");
+  REQUIRE(root.has_value());
+  REQUIRE(root->asObject().at("cursor").asString() == "abc123");
+}
+
+TEST_CASE("malformed paths throw instead of returning nullopt", "[expression][JsonPathExtractor]") {
+  auto response = json::parse(R"({"cursor": "abc123"})");
+
+  REQUIRE_THROWS_AS(JsonPathExtractor::extract(response, "cursor"), std::runtime_error);
+  REQUIRE_THROWS_AS(JsonPathExtractor::extract(response, ""), std::runtime_error);
+  REQUIRE_THROWS_AS(JsonPathExtractor::extract(response, "$cursor"), std::runtime_error);
+  REQUIRE_THROWS_AS(JsonPathExtractor::extract(response, "$.data."), std::runtime_error);
+  REQUIRE_THROWS_AS(JsonPathExtractor::extract(response, "$..data"), std::runtime_error);
+}

--- a/cpp/tests/expression/RequestExpressionEvaluatorTests.cpp
+++ b/cpp/tests/expression/RequestExpressionEvaluatorTests.cpp
@@ -1,0 +1,124 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../expression/RequestExpressionEvaluator.hpp"
+#include "../../platform/platform.hpp"
+#include "../../sync/SyncQueueReader.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+TEST_CASE("evaluates ConstantExpression", "[expression][RequestExpressionEvaluator]") {
+  auto noopResolver = [](const std::string&) -> json::Value { return json::Value(nullptr); };
+
+  REQUIRE(RequestExpressionEvaluator::evaluate(json::parse(R"({"value": 42})"), noopResolver).asNumber() == 42);
+  REQUIRE(RequestExpressionEvaluator::evaluate(json::parse(R"({"value": "abc"})"), noopResolver).asString() == "abc");
+  REQUIRE(RequestExpressionEvaluator::evaluate(json::parse(R"({"value": true})"), noopResolver).asBool() == true);
+  REQUIRE(RequestExpressionEvaluator::evaluate(json::parse(R"({"value": null})"), noopResolver).isNull());
+}
+
+TEST_CASE("evaluates nested multi-level ObjectExpression", "[expression][RequestExpressionEvaluator]") {
+  auto noopResolver = [](const std::string&) -> json::Value { return json::Value(nullptr); };
+
+  auto result = RequestExpressionEvaluator::evaluate(json::parse(R"({
+    "object": {
+      "a": { "value": 1 },
+      "b": { "object": { "c": { "value": 2 } } }
+    }
+  })"), noopResolver);
+
+  REQUIRE(result.asObject().at("a").asNumber() == 1);
+  REQUIRE(result.asObject().at("b").asObject().at("c").asNumber() == 2);
+}
+
+TEST_CASE("evaluates ArrayExpression with mixed nested items", "[expression][RequestExpressionEvaluator]") {
+  auto noopResolver = [](const std::string&) -> json::Value { return json::Value(nullptr); };
+
+  auto result = RequestExpressionEvaluator::evaluate(json::parse(R"({
+    "items": [
+      { "value": 1 },
+      { "object": { "x": { "value": 2 } } }
+    ]
+  })"), noopResolver);
+
+  REQUIRE(result.asArray().size() == 2);
+  REQUIRE(result.asArray()[0].asNumber() == 1);
+  REQUIRE(result.asArray()[1].asObject().at("x").asNumber() == 2);
+}
+
+TEST_CASE("resolves $ref: cursor and pageSize via the injected resolver", "[expression][RequestExpressionEvaluator]") {
+  auto resolver = [](const std::string& refName) -> json::Value {
+    if (refName == "cursor") return json::Value(std::string("abc123"));
+    if (refName == "pageSize") return json::Value(50.0);
+    FAIL("unexpected ref: " + refName);
+    return json::Value(nullptr);
+  };
+
+  REQUIRE(RequestExpressionEvaluator::evaluate(json::parse(R"({"$ref": "cursor"})"), resolver).asString() == "abc123");
+  REQUIRE(RequestExpressionEvaluator::evaluate(json::parse(R"({"$ref": "pageSize"})"), resolver).asNumber() == 50);
+}
+
+TEST_CASE("unimplemented MVP $refs throw without calling the resolver", "[expression][RequestExpressionEvaluator]") {
+  for (const std::string& ref : {"deviceId", "platform", "timestamp", "userId", "changes"}) {
+    auto expr = json::parse(R"({"$ref": ")" + ref + "\"}");
+    REQUIRE_THROWS_AS(
+      RequestExpressionEvaluator::evaluate(expr, [](const std::string&) -> json::Value {
+        FAIL("resolver should not be called for an unimplemented ref");
+        return json::Value(nullptr);
+      }),
+      std::runtime_error
+    );
+  }
+}
+
+TEST_CASE("unknown $ref outside the documented union throws", "[expression][RequestExpressionEvaluator]") {
+  REQUIRE_THROWS_AS(
+    RequestExpressionEvaluator::evaluate(json::parse(R"({"$ref": "somethingElse"})"), [](const std::string&) -> json::Value {
+      FAIL("resolver should not be called for an unknown ref");
+      return json::Value(nullptr);
+    }),
+    std::runtime_error
+  );
+}
+
+TEST_CASE("malformed or ambiguous expression nodes throw", "[expression][RequestExpressionEvaluator]") {
+  auto noopResolver = [](const std::string&) -> json::Value { return json::Value(nullptr); };
+
+  REQUIRE_THROWS_AS(RequestExpressionEvaluator::evaluate(json::parse(R"({"foo": "bar"})"), noopResolver), std::runtime_error);
+  REQUIRE_THROWS_AS(RequestExpressionEvaluator::evaluate(json::parse(R"({"$ref": "cursor", "value": 1})"), noopResolver), std::runtime_error);
+  REQUIRE_THROWS_AS(RequestExpressionEvaluator::evaluate(json::parse("42"), noopResolver), std::runtime_error);
+}
+
+TEST_CASE("composes a full request body with cursor/operations/pageSize wired to a real sync_queue", "[expression][RequestExpressionEvaluator][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(platform::getDocumentsDirectory() + "/evaluator_composition.db");
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" } },
+    "sync": { "enabled": true }
+  })"));
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+
+  SyncQueueReader reader(conn);
+  auto resolver = [&](const std::string& refName) -> json::Value {
+    if (refName == "cursor") return json::Value(std::string("abc123"));
+    if (refName == "pageSize") return json::Value(20.0);
+    if (refName == "operations") return json::Value(reader.readOperations(20));
+    FAIL("unexpected ref: " + refName);
+    return json::Value(nullptr);
+  };
+
+  auto body = RequestExpressionEvaluator::evaluate(json::parse(R"({
+    "object": {
+      "cursor": { "$ref": "cursor" },
+      "operations": { "$ref": "operations" },
+      "pageSize": { "$ref": "pageSize" }
+    }
+  })"), resolver);
+
+  const auto& obj = body.asObject();
+  REQUIRE(obj.at("cursor").asString() == "abc123");
+  REQUIRE(obj.at("pageSize").asNumber() == 20);
+  REQUIRE(obj.at("operations").asArray().size() == 1);
+  REQUIRE(obj.at("operations").asArray()[0].asObject().at("entity").asString() == "customers");
+}

--- a/cpp/tests/expression/RequestExpressionEvaluatorTests.cpp
+++ b/cpp/tests/expression/RequestExpressionEvaluatorTests.cpp
@@ -8,6 +8,15 @@
 
 using namespace margelo::nitro::salvedb;
 
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return platform::getDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+} // namespace
+
 TEST_CASE("evaluates ConstantExpression", "[expression][RequestExpressionEvaluator]") {
   auto noopResolver = [](const std::string&) -> json::Value { return json::Value(nullptr); };
 
@@ -90,7 +99,7 @@ TEST_CASE("malformed or ambiguous expression nodes throw", "[expression][Request
 }
 
 TEST_CASE("composes a full request body with cursor/operations/pageSize wired to a real sync_queue", "[expression][RequestExpressionEvaluator][integration]") {
-  auto conn = std::make_shared<SQLiteConnection>(platform::getDocumentsDirectory() + "/evaluator_composition.db");
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("evaluator_composition"));
   MigrationEngine engine(conn);
   engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
     "name": "customers", "version": 1, "primaryKey": "id",

--- a/cpp/tests/sync/SyncQueueReaderTests.cpp
+++ b/cpp/tests/sync/SyncQueueReaderTests.cpp
@@ -1,0 +1,75 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../platform/platform.hpp"
+#include "../../sync/SyncQueueReader.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return platform::getDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+void registerSyncEnabledCustomers(MigrationEngine& engine) {
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" } },
+    "sync": { "enabled": true }
+  })"));
+}
+
+} // namespace
+
+TEST_CASE("readOperations serializes sync_queue rows to the ISyncOperation shape", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_shape"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+
+  SyncQueueReader reader(conn);
+  auto ops = reader.readOperations(10);
+
+  REQUIRE(ops.size() == 1);
+  const auto& op = ops[0].asObject();
+  REQUIRE(op.at("operation").asString() == "insert");
+  REQUIRE(op.at("entity").asString() == "customers");
+  REQUIRE(op.at("primaryKey").asString() == "1");
+  REQUIRE(op.at("payload").isObject());
+  REQUIRE(op.at("updatedAt").isNumber());
+}
+
+TEST_CASE("readOperations respects the limit and returns oldest-first", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_limit"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+  conn->execute("INSERT INTO customers (id, name) VALUES (2, 'b')", {});
+  conn->execute("INSERT INTO customers (id, name) VALUES (3, 'c')", {});
+
+  SyncQueueReader reader(conn);
+  auto ops = reader.readOperations(2);
+
+  REQUIRE(ops.size() == 2);
+  REQUIRE(ops[0].asObject().at("primaryKey").asString() == "1");
+  REQUIRE(ops[1].asObject().at("primaryKey").asString() == "2");
+}
+
+TEST_CASE("readOperations does not mutate sync_queue", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_readonly"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+
+  SyncQueueReader reader(conn);
+  reader.readOperations(10);
+
+  auto rows = conn->execute("SELECT COUNT(*) FROM sync_queue", {});
+  REQUIRE(std::get<double>(rows.rows[0][0]) == 1.0);
+}

--- a/cpp/tests/sync/SyncQueueReaderTests.cpp
+++ b/cpp/tests/sync/SyncQueueReaderTests.cpp
@@ -73,3 +73,26 @@ TEST_CASE("readOperations does not mutate sync_queue", "[sync][SyncQueueReader]"
   auto rows = conn->execute("SELECT COUNT(*) FROM sync_queue", {});
   REQUIRE(std::get<double>(rows.rows[0][0]) == 1.0);
 }
+
+TEST_CASE("readOperations rejects a negative limit", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_negative_limit"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+
+  SyncQueueReader reader(conn);
+  REQUIRE_THROWS_AS(reader.readOperations(-1), std::runtime_error);
+}
+
+TEST_CASE("readOperations with limit 0 returns an empty array", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_zero_limit"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name) VALUES (1, 'a')", {});
+
+  SyncQueueReader reader(conn);
+  auto ops = reader.readOperations(0);
+  REQUIRE(ops.empty());
+}


### PR DESCRIPTION
## Summary
Closes #9

Implements the shared interpreter for declarative `RequestExpression`/`JsonPath` contracts (`docs/architecture.md` → "Request Expressions"/"JSON Path"), standalone and decoupled per the issue's own instruction — no external state, everything passed explicitly, no consumer wiring (that's TASK-009 `#10` and TASK-012 `#13`).

- `cpp/expression/RequestExpressionEvaluator.{hpp,cpp}` — evaluates `ConstantExpression`/`ObjectExpression`/`ArrayExpression`/`VariableExpression` into a request-body `json::Value`. Dispatch is structural (by which key is present), matching the TS union's lack of a discriminant tag. The 5 `$ref` values typed but unfed in the MVP (`deviceId`/`platform`/`timestamp`/`userId`/`changes`) are rejected before the resolver is ever called.
- `cpp/expression/JsonPathExtractor.{hpp,cpp}` — MVP JsonPath subset (`$.a.b`, dot-separated keys). Absent path (`std::nullopt`) is distinguishable from a path resolving to literal JSON `null`.
- `cpp/sync/SyncQueueReader.{hpp,cpp}` — real FIFO read of `sync_queue` with a limit, serialized to the `ISyncOperation` shape, resolving `$ref: "operations"` against real data (integration with TASK-006).
- `json::stringify` added to `cpp/database/json_parser.hpp` (only had `parse` before).
- Build wiring: `cpp/tests/CMakeLists.txt` and `android/CMakeLists.txt` (iOS podspec needs no change — already globs `cpp/**/*.{hpp,cpp}`).

4 of 6 acceptance criteria are checked off on #9. The other 2 are intentionally left open — see the status comment on #9 for why (they depend on state/consumers that belong to TASK-012 `#13` and TASK-009 `#10`, not this issue).

Also fixed during analysis, tracked separately (not part of this PR): #50 documents a pre-existing gap where credential refresh doesn't actually use `RequestExpression`/`$ref` in the implemented contract, despite docs/issue text suggesting otherwise.

## Test plan
- [x] `npm run test:native` — 149 assertions, 46 test cases, all green (17 new test cases covering every acceptance criterion)
- [x] No global state (`DatabaseManager::shared()`) used anywhere in `cpp/expression/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading queued synchronization operations in FIFO order with configurable limits.
  * Added JSON path extraction for nested values, including distinction between missing and explicitly null fields.
  * Added request-expression evaluation for values, objects, arrays, and supported references.
  * Added JSON serialization support for parsed values.

* **Tests**
  * Added coverage for expression evaluation, JSON path extraction, and sync queue reading, including validation and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->