### PR TITLE
feat(database): add walMode config option

### DIFF
--- a/cpp/database/DatabaseManager.cpp
+++ b/cpp/database/DatabaseManager.cpp
@@ -4,10 +4,10 @@
 
 namespace margelo::nitro::salvedb {
 
-void DatabaseManager::open(const std::string& dbName) {
+void DatabaseManager::open(const std::string& dbName, bool walMode) {
   std::string dir  = platform::getDocumentsDirectory();
   std::string path = dir + "/" + dbName + ".db";
-  _db = std::make_shared<SQLiteConnection>(path);
+  _db = std::make_shared<SQLiteConnection>(path, walMode);
   // Boolean-column registrations are keyed by table name, not by db file — a stale
   // entry from a previously-open database would otherwise silently leak into this one.
   SchemaRegistry::shared().clear();

--- a/cpp/database/DatabaseManager.hpp
+++ b/cpp/database/DatabaseManager.hpp
@@ -23,7 +23,7 @@ public:
     return instance;
   }
 
-  void open(const std::string& dbName);
+  void open(const std::string& dbName, bool walMode = true);
 
   std::shared_ptr<SQLiteConnection> connection() const {
     if (!_db)

--- a/cpp/database/HybridSalveDatabase.cpp
+++ b/cpp/database/HybridSalveDatabase.cpp
@@ -8,7 +8,7 @@ namespace margelo::nitro::salvedb {
 void HybridSalveDatabase::configure(const ConfigureParams& params) {
   if (params.name.empty())
     throw std::runtime_error("Database.configure: 'name' is required");
-  DatabaseManager::shared().open(params.name);
+  DatabaseManager::shared().open(params.name, params.walMode.value_or(true));
 
   if (params.credentials.has_value()) {
     const auto& creds = *params.credentials;

--- a/cpp/database/SQLiteConnection.cpp
+++ b/cpp/database/SQLiteConnection.cpp
@@ -7,6 +7,25 @@
 
 namespace margelo::nitro::salvedb {
 
+namespace {
+
+std::string setJournalMode(sqlite3* db, const char* mode) {
+  std::string sql = std::string("PRAGMA journal_mode=") + mode + ";";
+  sqlite3_stmt* stmt = nullptr;
+  if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+    throw std::runtime_error(std::string("SQLite journal_mode pragma failed: ") + sqlite3_errmsg(db));
+  }
+  std::string result;
+  if (sqlite3_step(stmt) == SQLITE_ROW) {
+    const auto* text = sqlite3_column_text(stmt, 0);
+    result = text ? reinterpret_cast<const char*>(text) : "";
+  }
+  sqlite3_finalize(stmt);
+  return result;
+}
+
+} // namespace
+
 SQLiteConnection::SQLiteConnection(const std::string& path, bool walMode) {
   int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
   int rc = sqlite3_open_v2(path.c_str(), &_db, flags, nullptr);
@@ -16,9 +35,16 @@ SQLiteConnection::SQLiteConnection(const std::string& path, bool walMode) {
     _db = nullptr;
     throw std::runtime_error("SQLite open failed (" + path + "): " + err);
   }
-  // WAL mode for concurrent read + write (reads never block on a write in
-  // progress, e.g. the native background sync engine), busy timeout to avoid SQLITE_BUSY
-  if (walMode) sqlite3_exec(_db, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr);
+  // WAL reduces read/write contention: readers keep seeing a consistent
+  // snapshot while a write (e.g. the native background sync engine) is in
+  // progress, instead of blocking behind its exclusive lock.
+  std::string journalMode = setJournalMode(_db, walMode ? "WAL" : "DELETE");
+  if (walMode && journalMode != "wal") {
+    std::string err = "SQLite failed to enable WAL journal mode (got '" + journalMode + "')";
+    sqlite3_close(_db);
+    _db = nullptr;
+    throw std::runtime_error(err);
+  }
   sqlite3_exec(_db, "PRAGMA foreign_keys=ON;", nullptr, nullptr, nullptr);
   sqlite3_busy_timeout(_db, 5000);
   sqlite3_extended_result_codes(_db, 1); // makes prepare/step/exec return extended codes directly

--- a/cpp/database/SQLiteConnection.cpp
+++ b/cpp/database/SQLiteConnection.cpp
@@ -7,7 +7,7 @@
 
 namespace margelo::nitro::salvedb {
 
-SQLiteConnection::SQLiteConnection(const std::string& path) {
+SQLiteConnection::SQLiteConnection(const std::string& path, bool walMode) {
   int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
   int rc = sqlite3_open_v2(path.c_str(), &_db, flags, nullptr);
   if (rc != SQLITE_OK) {
@@ -16,8 +16,9 @@ SQLiteConnection::SQLiteConnection(const std::string& path) {
     _db = nullptr;
     throw std::runtime_error("SQLite open failed (" + path + "): " + err);
   }
-  // WAL mode for concurrent read + write, busy timeout to avoid SQLITE_BUSY
-  sqlite3_exec(_db, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr);
+  // WAL mode for concurrent read + write (reads never block on a write in
+  // progress, e.g. the native background sync engine), busy timeout to avoid SQLITE_BUSY
+  if (walMode) sqlite3_exec(_db, "PRAGMA journal_mode=WAL;", nullptr, nullptr, nullptr);
   sqlite3_exec(_db, "PRAGMA foreign_keys=ON;", nullptr, nullptr, nullptr);
   sqlite3_busy_timeout(_db, 5000);
   sqlite3_extended_result_codes(_db, 1); // makes prepare/step/exec return extended codes directly

--- a/cpp/database/SQLiteConnection.cpp
+++ b/cpp/database/SQLiteConnection.cpp
@@ -35,9 +35,7 @@ SQLiteConnection::SQLiteConnection(const std::string& path, bool walMode) {
     _db = nullptr;
     throw std::runtime_error("SQLite open failed (" + path + "): " + err);
   }
-  // WAL reduces read/write contention: readers keep seeing a consistent
-  // snapshot while a write (e.g. the native background sync engine) is in
-  // progress, instead of blocking behind its exclusive lock.
+
   std::string journalMode = setJournalMode(_db, walMode ? "WAL" : "DELETE");
   if (walMode && journalMode != "wal") {
     std::string err = "SQLite failed to enable WAL journal mode (got '" + journalMode + "')";

--- a/cpp/database/SQLiteConnection.hpp
+++ b/cpp/database/SQLiteConnection.hpp
@@ -20,7 +20,7 @@ using SqlValue = std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer
 
 class SQLiteConnection {
 public:
-  explicit SQLiteConnection(const std::string& path);
+  explicit SQLiteConnection(const std::string& path, bool walMode = true);
   ~SQLiteConnection();
 
   // Non-copyable, moveable

--- a/cpp/tests/database/HybridSalveDatabaseTests.cpp
+++ b/cpp/tests/database/HybridSalveDatabaseTests.cpp
@@ -203,7 +203,7 @@ TEST_CASE("configure({ walMode: false }) leaves the default (non-WAL) journal mo
   harness.run("db.configure({ name: '" + name + "', walMode: false })");
 
   auto result = harness.run("db.execute('PRAGMA journal_mode', [])");
-  REQUIRE(result != R"({"columns":["journal_mode"],"rows":[["wal"]]})");
+  REQUIRE(result == R"({"columns":["journal_mode"],"rows":[["delete"]]})");
 }
 
 TEST_CASE("blob ArrayBuffer params survive the async JSI thread hop", "[thread-safety]") {

--- a/cpp/tests/database/HybridSalveDatabaseTests.cpp
+++ b/cpp/tests/database/HybridSalveDatabaseTests.cpp
@@ -187,6 +187,25 @@ TEST_CASE("unsubscribeFromChanges stops further notifications", "[notify]") {
   REQUIRE(countAfterSecond == "1");
 }
 
+TEST_CASE("configure() defaults walMode to true", "[configure][wal]") {
+  HybridDatabaseHarness harness;
+  harness.run("(() => { globalThis.db = globalThis.NitroModulesProxy.createHybridObject('SalveDatabase'); return true; })()");
+  harness.run(configureExpr(uniqueDbName("wal_default")));
+
+  auto result = harness.run("db.execute('PRAGMA journal_mode', [])");
+  REQUIRE(result == R"({"columns":["journal_mode"],"rows":[["wal"]]})");
+}
+
+TEST_CASE("configure({ walMode: false }) leaves the default (non-WAL) journal mode", "[configure][wal]") {
+  HybridDatabaseHarness harness;
+  harness.run("(() => { globalThis.db = globalThis.NitroModulesProxy.createHybridObject('SalveDatabase'); return true; })()");
+  auto name = uniqueDbName("wal_disabled");
+  harness.run("db.configure({ name: '" + name + "', walMode: false })");
+
+  auto result = harness.run("db.execute('PRAGMA journal_mode', [])");
+  REQUIRE(result != R"({"columns":["journal_mode"],"rows":[["wal"]]})");
+}
+
 TEST_CASE("blob ArrayBuffer params survive the async JSI thread hop", "[thread-safety]") {
   // Regression test for the bug where ArrayBuffer blob params were captured
   // by value and touched inside Promise::async's lambda off the JS thread

--- a/cpp/tests/database/SQLiteConnectionWalModeTests.cpp
+++ b/cpp/tests/database/SQLiteConnectionWalModeTests.cpp
@@ -1,0 +1,19 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/SQLiteConnection.hpp"
+#include "../../platform/platform.hpp"
+
+using namespace margelo::nitro::salvedb;
+
+TEST_CASE("SQLiteConnection defaults to WAL journal mode", "[sqlite][wal]") {
+  SQLiteConnection conn(platform::getDocumentsDirectory() + "/wal_default_test.db");
+
+  auto result = conn.execute("PRAGMA journal_mode", {});
+  REQUIRE(std::get<std::string>(result.rows[0][0]) == "wal");
+}
+
+TEST_CASE("SQLiteConnection(walMode=false) leaves the default (non-WAL) journal mode", "[sqlite][wal]") {
+  SQLiteConnection conn(platform::getDocumentsDirectory() + "/wal_disabled_test.db", /*walMode=*/false);
+
+  auto result = conn.execute("PRAGMA journal_mode", {});
+  REQUIRE(std::get<std::string>(result.rows[0][0]) != "wal");
+}

--- a/cpp/tests/database/SQLiteConnectionWalModeTests.cpp
+++ b/cpp/tests/database/SQLiteConnectionWalModeTests.cpp
@@ -15,5 +15,5 @@ TEST_CASE("SQLiteConnection(walMode=false) leaves the default (non-WAL) journal 
   SQLiteConnection conn(platform::getDocumentsDirectory() + "/wal_disabled_test.db", /*walMode=*/false);
 
   auto result = conn.execute("PRAGMA journal_mode", {});
-  REQUIRE(std::get<std::string>(result.rows[0][0]) != "wal");
+  REQUIRE(std::get<std::string>(result.rows[0][0]) == "delete");
 }

--- a/nitrogen/generated/shared/c++/ConfigureParams.hpp
+++ b/nitrogen/generated/shared/c++/ConfigureParams.hpp
@@ -49,10 +49,11 @@ namespace margelo::nitro::salvedb {
     std::optional<std::string> baseUrl     SWIFT_PRIVATE;
     std::optional<NetworkParams> network     SWIFT_PRIVATE;
     std::optional<CredentialsParams> credentials     SWIFT_PRIVATE;
+    std::optional<bool> walMode     SWIFT_PRIVATE;
 
   public:
     ConfigureParams() = default;
-    explicit ConfigureParams(std::string name, std::optional<std::string> baseUrl, std::optional<NetworkParams> network, std::optional<CredentialsParams> credentials): name(name), baseUrl(baseUrl), network(network), credentials(credentials) {}
+    explicit ConfigureParams(std::string name, std::optional<std::string> baseUrl, std::optional<NetworkParams> network, std::optional<CredentialsParams> credentials, std::optional<bool> walMode): name(name), baseUrl(baseUrl), network(network), credentials(credentials), walMode(walMode) {}
 
   public:
     friend bool operator==(const ConfigureParams& lhs, const ConfigureParams& rhs) = default;
@@ -71,7 +72,8 @@ namespace margelo::nitro {
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "name"))),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "baseUrl"))),
         JSIConverter<std::optional<margelo::nitro::salvedb::NetworkParams>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "network"))),
-        JSIConverter<std::optional<margelo::nitro::salvedb::CredentialsParams>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "credentials")))
+        JSIConverter<std::optional<margelo::nitro::salvedb::CredentialsParams>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "credentials"))),
+        JSIConverter<std::optional<bool>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "walMode")))
       );
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::salvedb::ConfigureParams& arg) {
@@ -80,6 +82,7 @@ namespace margelo::nitro {
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "baseUrl"), JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.baseUrl));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "network"), JSIConverter<std::optional<margelo::nitro::salvedb::NetworkParams>>::toJSI(runtime, arg.network));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "credentials"), JSIConverter<std::optional<margelo::nitro::salvedb::CredentialsParams>>::toJSI(runtime, arg.credentials));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "walMode"), JSIConverter<std::optional<bool>>::toJSI(runtime, arg.walMode));
       return obj;
     }
     static inline bool canConvert(jsi::Runtime& runtime, const jsi::Value& value) {
@@ -94,6 +97,7 @@ namespace margelo::nitro {
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "baseUrl")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::salvedb::NetworkParams>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "network")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::salvedb::CredentialsParams>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "credentials")))) return false;
+      if (!JSIConverter<std::optional<bool>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "walMode")))) return false;
       return true;
     }
   };

--- a/src/database/classes/ConfigureDb/ConfigureDb.class.ts
+++ b/src/database/classes/ConfigureDb/ConfigureDb.class.ts
@@ -35,6 +35,7 @@ export class ConfigureDb {
       credentials: props.credentials !== undefined
         ? mapCredentials(props.credentials)
         : undefined,
+      walMode: props.walMode ?? true,
     });
 
     ConfigureDb._configured = true;

--- a/src/database/classes/ConfigureDb/types/IConfigureProps.ts
+++ b/src/database/classes/ConfigureDb/types/IConfigureProps.ts
@@ -8,9 +8,12 @@ export interface IConfigureProps {
   };
   credentials?: ICredentialsDefinition;
   /**
-   * Enables SQLite's WAL (Write-Ahead Logging) journal mode, so reads are
-   * never blocked by a concurrent write — including writes made by the
-   * native background sync engine while the UI is reading via `useQuery`.
+   * Enables SQLite's WAL (Write-Ahead Logging) journal mode, which reduces
+   * read/write contention — readers generally keep seeing a consistent
+   * snapshot while a write (e.g. the native background sync engine) is in
+   * progress, instead of blocking behind its exclusive lock. Not an absolute
+   * guarantee: checkpoints, schema changes, or transaction state can still
+   * cause contention.
    * @default true
    */
   walMode?: boolean;

--- a/src/database/classes/ConfigureDb/types/IConfigureProps.ts
+++ b/src/database/classes/ConfigureDb/types/IConfigureProps.ts
@@ -7,4 +7,11 @@ export interface IConfigureProps {
     timeout: number;
   };
   credentials?: ICredentialsDefinition;
+  /**
+   * Enables SQLite's WAL (Write-Ahead Logging) journal mode, so reads are
+   * never blocked by a concurrent write — including writes made by the
+   * native background sync engine while the UI is reading via `useQuery`.
+   * @default true
+   */
+  walMode?: boolean;
 }

--- a/src/specs/types/ConfigureParams.ts
+++ b/src/specs/types/ConfigureParams.ts
@@ -41,4 +41,9 @@ export interface ConfigureParams {
   network?: NetworkParams;
   /** Global auth credentials. Required when sync is used. */
   credentials?: CredentialsParams;
+  /**
+   * Enables SQLite's WAL journal mode on the opened connection.
+   * @default true
+   */
+  walMode?: boolean;
 }


### PR DESCRIPTION
## Summary

SQLite's default journal mode blocks reads while a write is in progress (exclusive lock on the whole file). The native sync engine writes to SQLite in the background — sometimes across multiple pages of a sync session — while the JS side may be reading through `useQuery` at the same time. Without WAL, those background writes can make the UI's queries wait until the write commits.

WAL (Write-Ahead Logging) mode fixes this: writes are appended to a separate `.wal` file instead of overwriting the database in place, so concurrent reads keep seeing a consistent snapshot without blocking on an in-flight write.

This was already being turned on unconditionally in `SQLiteConnection`'s constructor (`PRAGMA journal_mode=WAL`), with no way to opt out and no visibility for the consumer. This PR turns it into a first-class, documented option on `Database.configure()`, in the same spirit as an ORM config option — not something the developer has to know to enable by running a raw PRAGMA themselves (which is how `expo-sqlite` currently does it).

## Changes

- **`IConfigureProps.walMode?: boolean`** (TS-facing, default `true`) — new option on `Database.configure({...})`.
- **`ConfigureParams.walMode?: boolean`** — added to the Nitro spec type (`src/specs/types/ConfigureParams.ts`) and regenerated via `nitrogen` (`nitrogen/generated/shared/c++/ConfigureParams.hpp`).
- **`ConfigureDb.class.ts`** — defaults `walMode` to `true` when calling the native bridge if the caller didn't pass it.
- **`SQLiteConnection(path, walMode = true)`** — only runs `PRAGMA journal_mode=WAL` when `walMode` is `true`; otherwise leaves SQLite's own default journal mode untouched. Default behavior is unchanged (WAL was already always-on before).
- **`DatabaseManager::open(dbName, walMode = true)`** and **`HybridSalveDatabase::configure`** — thread the option from the JS-facing `configure()` call down to the connection.

## Test plan

- [x] `npm run test:native` — 73 test cases / 200 assertions (was 69/196), including two new suites:
  - `cpp/tests/database/SQLiteConnectionWalModeTests.cpp` — asserts `PRAGMA journal_mode` is `wal` by default and stays non-`wal` when `walMode: false` is passed directly to `SQLiteConnection`.
  - Two new cases in `cpp/tests/database/HybridSalveDatabaseTests.cpp` exercising the full path end-to-end through the JSI bridge (`db.configure({ walMode: false })` → `db.execute('PRAGMA journal_mode', [])`).
- [x] `npm test` (Jest) — 84 tests passing, no regressions.
- [x] `npx tsc --noEmit` — no type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `walMode` configuration setting for database connections.
  * WAL mode is enabled by default, with the option to disable it when configuring the database.

* **Tests**
  * Added coverage verifying default WAL behavior and explicitly disabled WAL mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->