### PR TITLE
TASK-010: HTTP Client (Android+iOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ project.xcworkspace
 local.properties
 android.iml
 
+# Swift Package Manager
+.build/
+
 # Cocoapods
 #
 example/ios/Pods

--- a/SalveDb.podspec
+++ b/SalveDb.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     # Vendored SQLite amalgamation (same source used on Android)
     "cpp/third_party/sqlite3/*.{c,h}",
   ]
-  s.exclude_files = "cpp/tests/**/*"
+  s.exclude_files = ["cpp/tests/**/*", "ios/tests/**/*"]
 
   # Needed for sqlite3_column_table_name/origin_name, used to coerce boolean columns on read.
   s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SQLITE_ENABLE_COLUMN_METADATA=1' }

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/third_party/sqlite3/sqlite3.c
 	src/main/cpp/cpp-adapter.cpp
 	src/main/cpp/platform_android.cpp
+	src/main/cpp/JniSupport.cpp
 	../cpp/database/HybridSalveDatabase.cpp
 	../cpp/database/SQLiteConnection.cpp
 	../cpp/database/DatabaseManager.cpp
@@ -45,6 +46,7 @@ include_directories(
         "../cpp/sync"
         "../cpp/expression"
         "../cpp/credentials"
+        "../cpp/http"
         "../cpp/third_party/sqlite3"
 )
 

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -14,6 +14,9 @@ add_library(${PACKAGE_NAME} SHARED
 	src/main/cpp/cpp-adapter.cpp
 	src/main/cpp/platform_android.cpp
 	src/main/cpp/JniSupport.cpp
+	src/main/cpp/platform_android_http.cpp
+	../cpp/http/HttpUrlBuilder.cpp
+	../cpp/http/CredentialHttpCaller.cpp
 	../cpp/database/HybridSalveDatabase.cpp
 	../cpp/database/SQLiteConnection.cpp
 	../cpp/database/DatabaseManager.cpp

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -140,6 +140,9 @@ dependencies {
 
   // Keystore-backed encrypted storage for CredentialProvider.
   implementation "androidx.security:security-crypto:1.1.0-alpha06"
+
+  // Native HTTP client backing platform::httpExecute.
+  implementation "com.squareup.okhttp3:okhttp:4.12.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -143,6 +143,9 @@ dependencies {
 
   // Native HTTP client backing platform::httpExecute.
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
+
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/android/src/main/cpp/JniSupport.cpp
+++ b/android/src/main/cpp/JniSupport.cpp
@@ -1,0 +1,50 @@
+#include "JniSupport.hpp"
+#include <stdexcept>
+
+namespace margelo::nitro::salvedb::platform {
+
+namespace {
+JavaVM* s_javaVm = nullptr;
+} // namespace
+
+void registerJavaVM(JavaVM* vm) {
+  s_javaVm = vm;
+}
+
+ScopedJNIEnv::ScopedJNIEnv() {
+  if (!s_javaVm) {
+    throw std::runtime_error("SalveDb: JavaVM not registered — JNI_OnLoad must run before native JNI calls");
+  }
+  jint status = s_javaVm->GetEnv(reinterpret_cast<void**>(&_env), JNI_VERSION_1_6);
+  if (status == JNI_EDETACHED) {
+    if (s_javaVm->AttachCurrentThread(&_env, nullptr) != JNI_OK) {
+      throw std::runtime_error("SalveDb: failed to attach current thread to JVM");
+    }
+    _didAttach = true;
+  } else if (status != JNI_OK) {
+    throw std::runtime_error("SalveDb: JNI GetEnv failed");
+  }
+}
+
+ScopedJNIEnv::~ScopedJNIEnv() {
+  if (_didAttach) s_javaVm->DetachCurrentThread();
+}
+
+void throwIfJavaExceptionPending(JNIEnv* env, const std::string& context) {
+  if (!env->ExceptionCheck()) return;
+  env->ExceptionClear();
+  throw std::runtime_error("SalveDb: " + context + " threw a Java exception");
+}
+
+jclass resolveGlobalClass(JNIEnv* env, const char* binaryClassName) {
+  jclass localClass = env->FindClass(binaryClassName);
+  if (localClass == nullptr) {
+    env->ExceptionClear();
+    return nullptr;
+  }
+  jclass globalClass = static_cast<jclass>(env->NewGlobalRef(localClass));
+  env->DeleteLocalRef(localClass);
+  return globalClass;
+}
+
+} // namespace margelo::nitro::salvedb::platform

--- a/android/src/main/cpp/JniSupport.cpp
+++ b/android/src/main/cpp/JniSupport.cpp
@@ -30,6 +30,16 @@ ScopedJNIEnv::~ScopedJNIEnv() {
   if (_didAttach) s_javaVm->DetachCurrentThread();
 }
 
+ScopedLocalFrame::ScopedLocalFrame(JNIEnv* env, jint capacityHint) : _env(env) {
+  if (_env->PushLocalFrame(capacityHint) != 0) {
+    throw std::runtime_error("SalveDb: PushLocalFrame failed");
+  }
+}
+
+ScopedLocalFrame::~ScopedLocalFrame() {
+  _env->PopLocalFrame(nullptr);
+}
+
 void throwIfJavaExceptionPending(JNIEnv* env, const std::string& context) {
   if (!env->ExceptionCheck()) return;
   env->ExceptionClear();

--- a/android/src/main/cpp/JniSupport.hpp
+++ b/android/src/main/cpp/JniSupport.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <jni.h>
+#include <string>
+
+namespace margelo::nitro::salvedb::platform {
+
+// Stores the JavaVM* used by ScopedJNIEnv to attach/detach native threads.
+// Call once, before any ScopedJNIEnv is constructed (e.g. from JNI_OnLoad).
+void registerJavaVM(JavaVM* vm);
+
+// Attaches the current thread to the JVM on demand, detaches again on
+// destruction if this instance was the one that attached. Safe to
+// construct from any native thread, not just JNI-originated ones.
+class ScopedJNIEnv {
+public:
+  ScopedJNIEnv();
+  ~ScopedJNIEnv();
+  JNIEnv* env() const { return _env; }
+
+private:
+  JNIEnv* _env = nullptr;
+  bool _didAttach = false;
+};
+
+// Throws with `context` if a pending Java exception exists, clearing it —
+// otherwise a pending exception left on the JNIEnv corrupts the next call.
+void throwIfJavaExceptionPending(JNIEnv* env, const std::string& context);
+
+// Resolves and caches a global ref to `binaryClassName`. Returns nullptr
+// (clearing the pending exception) if the class can't be found.
+jclass resolveGlobalClass(JNIEnv* env, const char* binaryClassName);
+
+} // namespace margelo::nitro::salvedb::platform

--- a/android/src/main/cpp/JniSupport.hpp
+++ b/android/src/main/cpp/JniSupport.hpp
@@ -16,11 +16,28 @@ class ScopedJNIEnv {
 public:
   ScopedJNIEnv();
   ~ScopedJNIEnv();
+  ScopedJNIEnv(const ScopedJNIEnv&) = delete;
+  ScopedJNIEnv& operator=(const ScopedJNIEnv&) = delete;
   JNIEnv* env() const { return _env; }
 
 private:
   JNIEnv* _env = nullptr;
   bool _didAttach = false;
+};
+
+// Bounds the lifetime of local refs created after construction — pops them
+// all (via PopLocalFrame) on destruction, including on exception unwind.
+// Use around JNI calls that create several locals (arrays, strings,
+// intermediate objects) without deleting each one individually.
+class ScopedLocalFrame {
+public:
+  explicit ScopedLocalFrame(JNIEnv* env, jint capacityHint = 16);
+  ~ScopedLocalFrame();
+  ScopedLocalFrame(const ScopedLocalFrame&) = delete;
+  ScopedLocalFrame& operator=(const ScopedLocalFrame&) = delete;
+
+private:
+  JNIEnv* _env;
 };
 
 // Throws with `context` if a pending Java exception exists, clearing it —

--- a/android/src/main/cpp/platform_android.cpp
+++ b/android/src/main/cpp/platform_android.cpp
@@ -1,6 +1,7 @@
 #include "../../../../cpp/platform/platform.hpp"
 #include "../../../../cpp/platform/platform_android_jni.hpp"
 #include "JniSupport.hpp"
+#include "platform_android_http.hpp"
 #include <stdexcept>
 #include <string>
 
@@ -23,6 +24,7 @@ void setJavaVM(JavaVM* vm) {
   JNIEnv* env = nullptr;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) return;
   s_secureStorageClass = resolveGlobalClass(env, "com/salvedb/SalveDbSecureStorage");
+  registerHttpClientClass(resolveGlobalClass(env, "com/salvedb/http/SalveDbHttpClient"));
 }
 
 namespace {

--- a/android/src/main/cpp/platform_android.cpp
+++ b/android/src/main/cpp/platform_android.cpp
@@ -1,13 +1,12 @@
 #include "../../../../cpp/platform/platform.hpp"
 #include "../../../../cpp/platform/platform_android_jni.hpp"
-#include <jni.h>
+#include "JniSupport.hpp"
 #include <stdexcept>
 #include <string>
 
 namespace margelo::nitro::salvedb::platform {
 
 static std::string s_documentsDirectory;
-static JavaVM* s_javaVm = nullptr;
 static jclass s_secureStorageClass = nullptr;
 
 void setDocumentsDirectory(const std::string& path) {
@@ -19,17 +18,11 @@ std::string getDocumentsDirectory() {
 }
 
 void setJavaVM(JavaVM* vm) {
-  s_javaVm = vm;
+  registerJavaVM(vm);
 
   JNIEnv* env = nullptr;
   if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) return;
-  jclass localClass = env->FindClass("com/salvedb/SalveDbSecureStorage");
-  if (localClass == nullptr) {
-    env->ExceptionClear();
-    return;
-  }
-  s_secureStorageClass = static_cast<jclass>(env->NewGlobalRef(localClass));
-  env->DeleteLocalRef(localClass);
+  s_secureStorageClass = resolveGlobalClass(env, "com/salvedb/SalveDbSecureStorage");
 }
 
 namespace {
@@ -39,45 +32,6 @@ jclass secureStorageClass() {
     throw std::runtime_error("SalveDb: SalveDbSecureStorage class was not resolved — setJavaVM (JNI_OnLoad) must run first");
   }
   return s_secureStorageClass;
-}
-
-// Secure storage calls can happen from any native thread (foreground sync,
-// background sync worker), not just ones the JVM already attached — so this
-// attaches on demand and detaches again if it was the one that attached.
-class ScopedJNIEnv {
-public:
-  ScopedJNIEnv() {
-    if (!s_javaVm) {
-      throw std::runtime_error("SalveDb: JavaVM not set — JNI_OnLoad must run before secure storage access");
-    }
-    jint status = s_javaVm->GetEnv(reinterpret_cast<void**>(&_env), JNI_VERSION_1_6);
-    if (status == JNI_EDETACHED) {
-      if (s_javaVm->AttachCurrentThread(&_env, nullptr) != JNI_OK) {
-        throw std::runtime_error("SalveDb: failed to attach current thread to JVM");
-      }
-      _didAttach = true;
-    } else if (status != JNI_OK) {
-      throw std::runtime_error("SalveDb: JNI GetEnv failed");
-    }
-  }
-
-  ~ScopedJNIEnv() {
-    if (_didAttach) s_javaVm->DetachCurrentThread();
-  }
-
-  JNIEnv* env() const { return _env; }
-
-private:
-  JNIEnv* _env = nullptr;
-  bool _didAttach = false;
-};
-
-// Throws with `context` if a pending Java exception exists, clearing it —
-// otherwise a pending exception left on the JNIEnv corrupts the next call.
-void throwIfJavaExceptionPending(JNIEnv* env, const std::string& context) {
-  if (!env->ExceptionCheck()) return;
-  env->ExceptionClear();
-  throw std::runtime_error("SalveDb: " + context + " threw a Java exception");
 }
 
 } // namespace

--- a/android/src/main/cpp/platform_android_http.cpp
+++ b/android/src/main/cpp/platform_android_http.cpp
@@ -3,6 +3,7 @@
 #include "../../../../cpp/platform/platform.hpp"
 #include "JniSupport.hpp"
 #include <algorithm>
+#include <mutex>
 #include <stdexcept>
 
 namespace margelo::nitro::salvedb::platform {
@@ -28,24 +29,24 @@ jclass httpClientClass() {
   return s_httpClientClass;
 }
 
-// Idempotent — safe if raced from concurrent first calls, every thread
-// computes the same values.
-void ensureCached(JNIEnv* env) {
-  if (s_executeMethod) return;
+std::once_flag s_cacheOnceFlag;
 
-  s_resultClass = resolveGlobalClass(env, "com/salvedb/http/SalveDbHttpJniResult");
-  s_stringClass = resolveGlobalClass(env, "java/lang/String");
-  s_executeMethod = env->GetStaticMethodID(
-    httpClientClass(), "execute",
-    "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;J)Lcom/salvedb/http/SalveDbHttpJniResult;"
-  );
-  s_isSuccessField = env->GetFieldID(s_resultClass, "isSuccess", "Z");
-  s_statusCodeField = env->GetFieldID(s_resultClass, "statusCode", "I");
-  s_responseHeaderNamesField = env->GetFieldID(s_resultClass, "responseHeaderNames", "[Ljava/lang/String;");
-  s_responseHeaderValuesField = env->GetFieldID(s_resultClass, "responseHeaderValues", "[Ljava/lang/String;");
-  s_responseBodyField = env->GetFieldID(s_resultClass, "responseBody", "Ljava/lang/String;");
-  s_errorKindField = env->GetFieldID(s_resultClass, "errorKind", "Ljava/lang/String;");
-  s_errorMessageField = env->GetFieldID(s_resultClass, "errorMessage", "Ljava/lang/String;");
+void ensureCached(JNIEnv* env) {
+  std::call_once(s_cacheOnceFlag, [env]() {
+    s_resultClass = resolveGlobalClass(env, "com/salvedb/http/SalveDbHttpJniResult");
+    s_stringClass = resolveGlobalClass(env, "java/lang/String");
+    s_executeMethod = env->GetStaticMethodID(
+      httpClientClass(), "execute",
+      "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;J)Lcom/salvedb/http/SalveDbHttpJniResult;"
+    );
+    s_isSuccessField = env->GetFieldID(s_resultClass, "isSuccess", "Z");
+    s_statusCodeField = env->GetFieldID(s_resultClass, "statusCode", "I");
+    s_responseHeaderNamesField = env->GetFieldID(s_resultClass, "responseHeaderNames", "[Ljava/lang/String;");
+    s_responseHeaderValuesField = env->GetFieldID(s_resultClass, "responseHeaderValues", "[Ljava/lang/String;");
+    s_responseBodyField = env->GetFieldID(s_resultClass, "responseBody", "Ljava/lang/String;");
+    s_errorKindField = env->GetFieldID(s_resultClass, "errorKind", "Ljava/lang/String;");
+    s_errorMessageField = env->GetFieldID(s_resultClass, "errorMessage", "Ljava/lang/String;");
+  });
 }
 
 const char* methodName(HttpMethod method) {
@@ -77,6 +78,7 @@ jobjectArray toJStringArray(JNIEnv* env, const std::vector<std::string>& values)
 }
 
 std::string jstringToStd(JNIEnv* env, jstring value) {
+  if (!value) return "";
   const char* chars = env->GetStringUTFChars(value, nullptr);
   std::string result(chars);
   env->ReleaseStringUTFChars(value, chars);
@@ -94,6 +96,11 @@ HttpOutcome httpExecute(const HttpRequest& request) {
   JNIEnv* env = scoped.env();
   jclass cls = httpClientClass();
   ensureCached(env);
+
+  // Bounds every local ref created below (request/response strings, arrays,
+  // the result object) — freed on return or on exception unwind, so a reused
+  // attached thread issuing many requests never accumulates local refs.
+  ScopedLocalFrame frame(env);
 
   std::vector<std::string> headerNames;
   std::vector<std::string> headerValues;
@@ -113,12 +120,6 @@ HttpOutcome httpExecute(const HttpRequest& request) {
   jobject jResult = env->CallStaticObjectMethod(
     cls, s_executeMethod, jMethod, jUrl, jHeaderNames, jHeaderValues, jBody, static_cast<jlong>(request.timeoutMs)
   );
-
-  env->DeleteLocalRef(jMethod);
-  env->DeleteLocalRef(jUrl);
-  env->DeleteLocalRef(jHeaderNames);
-  env->DeleteLocalRef(jHeaderValues);
-  if (jBody) env->DeleteLocalRef(jBody);
   throwIfJavaExceptionPending(env, "SalveDbHttpClient.execute");
 
   if (env->GetBooleanField(jResult, s_isSuccessField)) {
@@ -134,8 +135,6 @@ HttpOutcome httpExecute(const HttpRequest& request) {
       auto name = static_cast<jstring>(env->GetObjectArrayElement(jRespHeaderNames, i));
       auto value = static_cast<jstring>(env->GetObjectArrayElement(jRespHeaderValues, i));
       headers.emplace_back(jstringToStd(env, name), jstringToStd(env, value));
-      env->DeleteLocalRef(name);
-      env->DeleteLocalRef(value);
     }
 
     return HttpResponse{statusCode, std::move(headers), jstringToStd(env, jRespBody)};

--- a/android/src/main/cpp/platform_android_http.cpp
+++ b/android/src/main/cpp/platform_android_http.cpp
@@ -1,0 +1,149 @@
+#include "platform_android_http.hpp"
+#include "../../../../cpp/http/HttpTypes.hpp"
+#include "../../../../cpp/platform/platform.hpp"
+#include "JniSupport.hpp"
+#include <algorithm>
+#include <stdexcept>
+
+namespace margelo::nitro::salvedb::platform {
+
+namespace {
+
+jclass s_httpClientClass = nullptr;
+jclass s_resultClass = nullptr;
+jclass s_stringClass = nullptr;
+jmethodID s_executeMethod = nullptr;
+jfieldID s_isSuccessField = nullptr;
+jfieldID s_statusCodeField = nullptr;
+jfieldID s_responseHeaderNamesField = nullptr;
+jfieldID s_responseHeaderValuesField = nullptr;
+jfieldID s_responseBodyField = nullptr;
+jfieldID s_errorKindField = nullptr;
+jfieldID s_errorMessageField = nullptr;
+
+jclass httpClientClass() {
+  if (!s_httpClientClass) {
+    throw std::runtime_error("SalveDb: SalveDbHttpClient class was not resolved — setJavaVM (JNI_OnLoad) must run first");
+  }
+  return s_httpClientClass;
+}
+
+// Idempotent — safe if raced from concurrent first calls, every thread
+// computes the same values.
+void ensureCached(JNIEnv* env) {
+  if (s_executeMethod) return;
+
+  s_resultClass = resolveGlobalClass(env, "com/salvedb/http/SalveDbHttpJniResult");
+  s_stringClass = resolveGlobalClass(env, "java/lang/String");
+  s_executeMethod = env->GetStaticMethodID(
+    httpClientClass(), "execute",
+    "(Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;J)Lcom/salvedb/http/SalveDbHttpJniResult;"
+  );
+  s_isSuccessField = env->GetFieldID(s_resultClass, "isSuccess", "Z");
+  s_statusCodeField = env->GetFieldID(s_resultClass, "statusCode", "I");
+  s_responseHeaderNamesField = env->GetFieldID(s_resultClass, "responseHeaderNames", "[Ljava/lang/String;");
+  s_responseHeaderValuesField = env->GetFieldID(s_resultClass, "responseHeaderValues", "[Ljava/lang/String;");
+  s_responseBodyField = env->GetFieldID(s_resultClass, "responseBody", "Ljava/lang/String;");
+  s_errorKindField = env->GetFieldID(s_resultClass, "errorKind", "Ljava/lang/String;");
+  s_errorMessageField = env->GetFieldID(s_resultClass, "errorMessage", "Ljava/lang/String;");
+}
+
+const char* methodName(HttpMethod method) {
+  switch (method) {
+    case HttpMethod::Get: return "GET";
+    case HttpMethod::Post: return "POST";
+    case HttpMethod::Put: return "PUT";
+    case HttpMethod::Patch: return "PATCH";
+    case HttpMethod::Delete: return "DELETE";
+  }
+  throw std::runtime_error("SalveDb: unknown HttpMethod");
+}
+
+HttpNetworkErrorKind parseErrorKind(const std::string& kind) {
+  if (kind == "TIMEOUT") return HttpNetworkErrorKind::Timeout;
+  if (kind == "NO_CONNECTION") return HttpNetworkErrorKind::NoConnection;
+  if (kind == "CANCELLED") return HttpNetworkErrorKind::Cancelled;
+  return HttpNetworkErrorKind::Other;
+}
+
+jobjectArray toJStringArray(JNIEnv* env, const std::vector<std::string>& values) {
+  jobjectArray array = env->NewObjectArray(static_cast<jsize>(values.size()), s_stringClass, nullptr);
+  for (size_t i = 0; i < values.size(); i++) {
+    jstring value = env->NewStringUTF(values[i].c_str());
+    env->SetObjectArrayElement(array, static_cast<jsize>(i), value);
+    env->DeleteLocalRef(value);
+  }
+  return array;
+}
+
+std::string jstringToStd(JNIEnv* env, jstring value) {
+  const char* chars = env->GetStringUTFChars(value, nullptr);
+  std::string result(chars);
+  env->ReleaseStringUTFChars(value, chars);
+  return result;
+}
+
+} // namespace
+
+void registerHttpClientClass(jclass cls) {
+  s_httpClientClass = cls;
+}
+
+HttpOutcome httpExecute(const HttpRequest& request) {
+  ScopedJNIEnv scoped;
+  JNIEnv* env = scoped.env();
+  jclass cls = httpClientClass();
+  ensureCached(env);
+
+  std::vector<std::string> headerNames;
+  std::vector<std::string> headerValues;
+  headerNames.reserve(request.headers.size());
+  headerValues.reserve(request.headers.size());
+  for (const auto& [name, value] : request.headers) {
+    headerNames.push_back(name);
+    headerValues.push_back(value);
+  }
+
+  jstring jMethod = env->NewStringUTF(methodName(request.method));
+  jstring jUrl = env->NewStringUTF(request.url.c_str());
+  jobjectArray jHeaderNames = toJStringArray(env, headerNames);
+  jobjectArray jHeaderValues = toJStringArray(env, headerValues);
+  jstring jBody = request.body.has_value() ? env->NewStringUTF(request.body->c_str()) : nullptr;
+
+  jobject jResult = env->CallStaticObjectMethod(
+    cls, s_executeMethod, jMethod, jUrl, jHeaderNames, jHeaderValues, jBody, static_cast<jlong>(request.timeoutMs)
+  );
+
+  env->DeleteLocalRef(jMethod);
+  env->DeleteLocalRef(jUrl);
+  env->DeleteLocalRef(jHeaderNames);
+  env->DeleteLocalRef(jHeaderValues);
+  if (jBody) env->DeleteLocalRef(jBody);
+  throwIfJavaExceptionPending(env, "SalveDbHttpClient.execute");
+
+  if (env->GetBooleanField(jResult, s_isSuccessField)) {
+    int statusCode = env->GetIntField(jResult, s_statusCodeField);
+    auto jRespHeaderNames = static_cast<jobjectArray>(env->GetObjectField(jResult, s_responseHeaderNamesField));
+    auto jRespHeaderValues = static_cast<jobjectArray>(env->GetObjectField(jResult, s_responseHeaderValuesField));
+    auto jRespBody = static_cast<jstring>(env->GetObjectField(jResult, s_responseBodyField));
+
+    jsize count = std::min(env->GetArrayLength(jRespHeaderNames), env->GetArrayLength(jRespHeaderValues));
+    HttpHeaders headers;
+    headers.reserve(count);
+    for (jsize i = 0; i < count; i++) {
+      auto name = static_cast<jstring>(env->GetObjectArrayElement(jRespHeaderNames, i));
+      auto value = static_cast<jstring>(env->GetObjectArrayElement(jRespHeaderValues, i));
+      headers.emplace_back(jstringToStd(env, name), jstringToStd(env, value));
+      env->DeleteLocalRef(name);
+      env->DeleteLocalRef(value);
+    }
+
+    return HttpResponse{statusCode, std::move(headers), jstringToStd(env, jRespBody)};
+  }
+
+  auto jErrorKind = static_cast<jstring>(env->GetObjectField(jResult, s_errorKindField));
+  auto jErrorMessage = static_cast<jstring>(env->GetObjectField(jResult, s_errorMessageField));
+  return HttpNetworkError{parseErrorKind(jstringToStd(env, jErrorKind)), jstringToStd(env, jErrorMessage)};
+}
+
+} // namespace margelo::nitro::salvedb::platform

--- a/android/src/main/cpp/platform_android_http.hpp
+++ b/android/src/main/cpp/platform_android_http.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <jni.h>
+
+namespace margelo::nitro::salvedb::platform {
+
+// Called once from setJavaVM (JNI_OnLoad) to cache the SalveDbHttpClient class.
+void registerHttpClientClass(jclass cls);
+
+} // namespace margelo::nitro::salvedb::platform

--- a/android/src/main/java/com/salvedb/SalveDbHttpClient.kt
+++ b/android/src/main/java/com/salvedb/SalveDbHttpClient.kt
@@ -1,0 +1,26 @@
+package com.salvedb
+
+import com.salvedb.http.OkHttpAdapter
+import com.salvedb.http.SalveDbHttpJniResult
+import com.salvedb.http.SalveDbHttpMethod
+import com.salvedb.http.SalveDbHttpRequest
+
+// Thin JNI-facing entry point for platform::httpExecute (android/src/main/cpp/platform_android_http.cpp).
+object SalveDbHttpClient {
+  private val adapter = OkHttpAdapter()
+
+  @JvmStatic
+  fun execute(
+    method: String,
+    url: String,
+    headerNames: Array<String>,
+    headerValues: Array<String>,
+    body: String?,
+    timeoutMs: Long,
+  ): SalveDbHttpJniResult {
+    val headerCount = minOf(headerNames.size, headerValues.size)
+    val headers = (0 until headerCount).map { headerNames[it] to headerValues[it] }
+    val request = SalveDbHttpRequest(SalveDbHttpMethod.valueOf(method), url, headers, body, timeoutMs)
+    return SalveDbHttpJniResult.from(adapter.execute(request))
+  }
+}

--- a/android/src/main/java/com/salvedb/SalveDbHttpClient.kt
+++ b/android/src/main/java/com/salvedb/SalveDbHttpClient.kt
@@ -1,13 +1,16 @@
 package com.salvedb
 
 import com.salvedb.http.OkHttpAdapter
+import com.salvedb.http.SalveDbHttpErrorKind
 import com.salvedb.http.SalveDbHttpJniResult
 import com.salvedb.http.SalveDbHttpMethod
+import com.salvedb.http.SalveDbHttpOutcome
 import com.salvedb.http.SalveDbHttpRequest
 
 // Thin JNI-facing entry point for platform::httpExecute (android/src/main/cpp/platform_android_http.cpp).
 object SalveDbHttpClient {
   private val adapter = OkHttpAdapter()
+  private val methodsByName = SalveDbHttpMethod.entries.associateBy { it.name }
 
   @JvmStatic
   fun execute(
@@ -18,9 +21,14 @@ object SalveDbHttpClient {
     body: String?,
     timeoutMs: Long,
   ): SalveDbHttpJniResult {
+    val httpMethod = methodsByName[method]
+      ?: return SalveDbHttpJniResult.from(
+        SalveDbHttpOutcome.NetworkError(SalveDbHttpErrorKind.OTHER, "unknown HTTP method: $method")
+      )
+
     val headerCount = minOf(headerNames.size, headerValues.size)
     val headers = (0 until headerCount).map { headerNames[it] to headerValues[it] }
-    val request = SalveDbHttpRequest(SalveDbHttpMethod.valueOf(method), url, headers, body, timeoutMs)
+    val request = SalveDbHttpRequest(httpMethod, url, headers, body, timeoutMs)
     return SalveDbHttpJniResult.from(adapter.execute(request))
   }
 }

--- a/android/src/main/java/com/salvedb/http/OkHttpAdapter.kt
+++ b/android/src/main/java/com/salvedb/http/OkHttpAdapter.kt
@@ -7,11 +7,18 @@ import okhttp3.OkHttpClient
 class OkHttpAdapter {
 
   fun execute(request: SalveDbHttpRequest): SalveDbHttpOutcome {
-    val call = client
-      .newBuilder()
-      .callTimeout(request.timeoutMs, TimeUnit.MILLISECONDS)
-      .build()
-      .newCall(request.toOkHttpRequest())
+    // Building the request/Call can throw IllegalArgumentException (OkHttp's
+    // HttpUrl/Headers.Builder validation) for a malformed URL or header —
+    // handled separately from IOException since no cancellable Call exists yet.
+    val call = try {
+      client
+        .newBuilder()
+        .callTimeout(request.timeoutMs, TimeUnit.MILLISECONDS)
+        .build()
+        .newCall(request.toOkHttpRequest())
+    } catch (e: IllegalArgumentException) {
+      return SalveDbHttpOutcome.NetworkError(SalveDbHttpErrorKind.OTHER, e.message ?: e.toString())
+    }
 
     return try {
       call.execute().use { it.toSalveDbHttpOutcome() }

--- a/android/src/main/java/com/salvedb/http/OkHttpAdapter.kt
+++ b/android/src/main/java/com/salvedb/http/OkHttpAdapter.kt
@@ -1,0 +1,24 @@
+package com.salvedb.http
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+
+class OkHttpAdapter {
+
+  fun execute(request: SalveDbHttpRequest): SalveDbHttpOutcome {
+    val call = client
+      .newBuilder()
+      .callTimeout(request.timeoutMs, TimeUnit.MILLISECONDS)
+      .build()
+      .newCall(request.toOkHttpRequest())
+
+    return try {
+      call.execute().use { it.toSalveDbHttpOutcome() }
+    } catch (e: IOException) {
+      SalveDbHttpOutcome.NetworkError(SalveDbHttpErrorKind.from(e, call.isCanceled()), e.message ?: e.toString())
+    }
+  }
+
+  private val client: OkHttpClient by lazy { OkHttpClient() }
+}

--- a/android/src/main/java/com/salvedb/http/Response+toSalveDbHttpOutcome.kt
+++ b/android/src/main/java/com/salvedb/http/Response+toSalveDbHttpOutcome.kt
@@ -1,0 +1,8 @@
+package com.salvedb.http
+
+import okhttp3.Response
+
+internal fun Response.toSalveDbHttpOutcome(): SalveDbHttpOutcome {
+  val headerPairs = (0 until headers.size).map { headers.name(it) to headers.value(it) }
+  return SalveDbHttpOutcome.Success(code, headerPairs, body?.string() ?: "")
+}

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpErrorKind.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpErrorKind.kt
@@ -1,0 +1,23 @@
+package com.salvedb.http
+
+import java.io.InterruptedIOException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+
+enum class SalveDbHttpErrorKind {
+  TIMEOUT,
+  NO_CONNECTION,
+  CANCELLED,
+  OTHER;
+
+  companion object {
+    fun from(exception: Throwable, isCancelled: Boolean): SalveDbHttpErrorKind = when {
+      isCancelled -> CANCELLED
+      exception is SocketTimeoutException -> TIMEOUT
+      exception is InterruptedIOException && exception.message == "timeout" -> TIMEOUT
+      exception is UnknownHostException || exception is ConnectException -> NO_CONNECTION
+      else -> OTHER
+    }
+  }
+}

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpErrorKind.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpErrorKind.kt
@@ -12,10 +12,13 @@ enum class SalveDbHttpErrorKind {
   OTHER;
 
   companion object {
+    // OkHttp's own callTimeout cancels the call internally when it fires, so
+    // isCancelled is true for both a real cancel() and a timeout — the
+    // exception shape must be checked first to tell them apart.
     fun from(exception: Throwable, isCancelled: Boolean): SalveDbHttpErrorKind = when {
-      isCancelled -> CANCELLED
       exception is SocketTimeoutException -> TIMEOUT
       exception is InterruptedIOException && exception.message == "timeout" -> TIMEOUT
+      isCancelled -> CANCELLED
       exception is UnknownHostException || exception is ConnectException -> NO_CONNECTION
       else -> OTHER
     }

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpJniResult.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpJniResult.kt
@@ -1,0 +1,37 @@
+package com.salvedb.http
+
+// JNI marshaling type only — native code reads these fields directly via
+// cached JNI field IDs (@JvmField keeps them plain public fields). Not used
+// anywhere else in Kotlin.
+class SalveDbHttpJniResult private constructor(
+  @JvmField val isSuccess: Boolean,
+  @JvmField val statusCode: Int,
+  @JvmField val responseHeaderNames: Array<String>,
+  @JvmField val responseHeaderValues: Array<String>,
+  @JvmField val responseBody: String,
+  @JvmField val errorKind: String,
+  @JvmField val errorMessage: String,
+) {
+  companion object {
+    fun from(outcome: SalveDbHttpOutcome): SalveDbHttpJniResult = when (outcome) {
+      is SalveDbHttpOutcome.Success -> SalveDbHttpJniResult(
+        isSuccess = true,
+        statusCode = outcome.statusCode,
+        responseHeaderNames = outcome.headers.map { it.first }.toTypedArray(),
+        responseHeaderValues = outcome.headers.map { it.second }.toTypedArray(),
+        responseBody = outcome.body,
+        errorKind = "",
+        errorMessage = "",
+      )
+      is SalveDbHttpOutcome.NetworkError -> SalveDbHttpJniResult(
+        isSuccess = false,
+        statusCode = 0,
+        responseHeaderNames = emptyArray(),
+        responseHeaderValues = emptyArray(),
+        responseBody = "",
+        errorKind = outcome.kind.name,
+        errorMessage = outcome.message,
+      )
+    }
+  }
+}

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpMethod.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpMethod.kt
@@ -1,0 +1,3 @@
+package com.salvedb.http
+
+enum class SalveDbHttpMethod { GET, POST, PUT, PATCH, DELETE }

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpOutcome.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpOutcome.kt
@@ -1,0 +1,6 @@
+package com.salvedb.http
+
+sealed interface SalveDbHttpOutcome {
+  data class Success(val statusCode: Int, val headers: List<Pair<String, String>>, val body: String) : SalveDbHttpOutcome
+  data class NetworkError(val kind: SalveDbHttpErrorKind, val message: String) : SalveDbHttpOutcome
+}

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpRequest+toOkHttpRequest.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpRequest+toOkHttpRequest.kt
@@ -1,0 +1,22 @@
+package com.salvedb.http
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+private val EMPTY_BODY = "".toRequestBody(JSON_MEDIA_TYPE)
+
+internal fun SalveDbHttpRequest.toOkHttpRequest(): Request {
+  val builder = Request.Builder().url(url)
+  headers.forEach { (name, value) -> builder.addHeader(name, value) }
+
+  val requestBody = body?.toRequestBody(JSON_MEDIA_TYPE)
+  return when (method) {
+    SalveDbHttpMethod.GET -> builder.get()
+    SalveDbHttpMethod.DELETE -> if (requestBody != null) builder.delete(requestBody) else builder.delete()
+    SalveDbHttpMethod.POST -> builder.post(requestBody ?: EMPTY_BODY)
+    SalveDbHttpMethod.PUT -> builder.put(requestBody ?: EMPTY_BODY)
+    SalveDbHttpMethod.PATCH -> builder.patch(requestBody ?: EMPTY_BODY)
+  }.build()
+}

--- a/android/src/main/java/com/salvedb/http/SalveDbHttpRequest.kt
+++ b/android/src/main/java/com/salvedb/http/SalveDbHttpRequest.kt
@@ -1,0 +1,9 @@
+package com.salvedb.http
+
+data class SalveDbHttpRequest(
+  val method: SalveDbHttpMethod,
+  val url: String,
+  val headers: List<Pair<String, String>>,
+  val body: String?,
+  val timeoutMs: Long,
+)

--- a/android/src/test/java/com/salvedb/SalveDbHttpClientTest.kt
+++ b/android/src/test/java/com/salvedb/SalveDbHttpClientTest.kt
@@ -1,0 +1,15 @@
+package com.salvedb
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class SalveDbHttpClientTest {
+
+  @Test
+  fun `an unrecognized HTTP method returns a graceful OTHER error instead of throwing`() {
+    val result = SalveDbHttpClient.execute("PURGE", "https://example.com", emptyArray(), emptyArray(), null, 5000)
+    assertFalse(result.isSuccess)
+    assertEquals("OTHER", result.errorKind)
+  }
+}

--- a/android/src/test/java/com/salvedb/http/OkHttpAdapterTest.kt
+++ b/android/src/test/java/com/salvedb/http/OkHttpAdapterTest.kt
@@ -124,4 +124,10 @@ class OkHttpAdapterTest {
     val outcome = adapter.execute(request(SalveDbHttpMethod.GET)) as SalveDbHttpOutcome.Success
     assertTrue(outcome.headers.any { it.first == "X-Reply" && it.second == "value" })
   }
+
+  @Test
+  fun `a malformed URL produces a NetworkError instead of throwing`() {
+    val outcome = adapter.execute(SalveDbHttpRequest(SalveDbHttpMethod.GET, "ht!tp://[invalid", emptyList(), null, 5000))
+    assertTrue(outcome is SalveDbHttpOutcome.NetworkError)
+  }
 }

--- a/android/src/test/java/com/salvedb/http/OkHttpAdapterTest.kt
+++ b/android/src/test/java/com/salvedb/http/OkHttpAdapterTest.kt
@@ -1,0 +1,127 @@
+package com.salvedb.http
+
+import java.util.concurrent.TimeUnit
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class OkHttpAdapterTest {
+
+  private lateinit var server: MockWebServer
+  private val adapter = OkHttpAdapter()
+
+  @Before
+  fun setUp() {
+    server = MockWebServer()
+    server.start()
+  }
+
+  @After
+  fun tearDown() {
+    server.shutdown()
+  }
+
+  private fun request(
+    method: SalveDbHttpMethod,
+    headers: List<Pair<String, String>> = emptyList(),
+    body: String? = null,
+    timeoutMs: Long = 5000,
+  ) = SalveDbHttpRequest(method, server.url("/").toString(), headers, body, timeoutMs)
+
+  @Test
+  fun `GET returns the mocked status and body`() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody("hello"))
+
+    val outcome = adapter.execute(request(SalveDbHttpMethod.GET)) as SalveDbHttpOutcome.Success
+    assertEquals(200, outcome.statusCode)
+    assertEquals("hello", outcome.body)
+  }
+
+  @Test
+  fun `POST sends the request body intact`() {
+    server.enqueue(MockResponse().setResponseCode(201))
+
+    adapter.execute(request(SalveDbHttpMethod.POST, body = """{"a":1}"""))
+
+    val recorded = server.takeRequest()
+    assertEquals("POST", recorded.method)
+    assertEquals("""{"a":1}""", recorded.body.readUtf8())
+  }
+
+  @Test
+  fun `PUT sends the request body intact`() {
+    server.enqueue(MockResponse().setResponseCode(200))
+    adapter.execute(request(SalveDbHttpMethod.PUT, body = """{"a":2}"""))
+    assertEquals("PUT", server.takeRequest().method)
+  }
+
+  @Test
+  fun `PATCH sends the request body intact`() {
+    server.enqueue(MockResponse().setResponseCode(200))
+    adapter.execute(request(SalveDbHttpMethod.PATCH, body = """{"a":3}"""))
+    assertEquals("PATCH", server.takeRequest().method)
+  }
+
+  @Test
+  fun `DELETE without a body succeeds`() {
+    server.enqueue(MockResponse().setResponseCode(204))
+    val outcome = adapter.execute(request(SalveDbHttpMethod.DELETE)) as SalveDbHttpOutcome.Success
+    assertEquals(204, outcome.statusCode)
+    assertEquals("DELETE", server.takeRequest().method)
+  }
+
+  @Test
+  fun `a 500 response is a Success outcome, not a network error`() {
+    server.enqueue(MockResponse().setResponseCode(500).setBody("boom"))
+
+    val outcome = adapter.execute(request(SalveDbHttpMethod.GET))
+    assertTrue(outcome is SalveDbHttpOutcome.Success)
+    assertEquals(500, (outcome as SalveDbHttpOutcome.Success).statusCode)
+  }
+
+  @Test
+  fun `a shutdown server produces a NetworkError`() {
+    val url = server.url("/").toString()
+    server.shutdown()
+
+    val outcome = adapter.execute(SalveDbHttpRequest(SalveDbHttpMethod.GET, url, emptyList(), null, 2000))
+    assertTrue(outcome is SalveDbHttpOutcome.NetworkError)
+  }
+
+  @Test
+  fun `a slow response beyond the timeout produces a TIMEOUT NetworkError`() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody("slow-response").setBodyDelay(2, TimeUnit.SECONDS))
+
+    val outcome = adapter.execute(request(SalveDbHttpMethod.GET, timeoutMs = 200))
+    assertTrue(outcome is SalveDbHttpOutcome.NetworkError)
+    assertEquals(SalveDbHttpErrorKind.TIMEOUT, (outcome as SalveDbHttpOutcome.NetworkError).kind)
+  }
+
+  @Test
+  fun `custom headers and an auth-like header coexist without overwriting`() {
+    server.enqueue(MockResponse().setResponseCode(200))
+
+    adapter.execute(
+      request(
+        SalveDbHttpMethod.GET,
+        headers = listOf("X-Custom" to "custom-value", "Authorization" to "Bearer token"),
+      )
+    )
+
+    val recorded = server.takeRequest()
+    assertEquals("custom-value", recorded.getHeader("X-Custom"))
+    assertEquals("Bearer token", recorded.getHeader("Authorization"))
+  }
+
+  @Test
+  fun `response headers are returned`() {
+    server.enqueue(MockResponse().setResponseCode(200).addHeader("X-Reply", "value"))
+
+    val outcome = adapter.execute(request(SalveDbHttpMethod.GET)) as SalveDbHttpOutcome.Success
+    assertTrue(outcome.headers.any { it.first == "X-Reply" && it.second == "value" })
+  }
+}

--- a/cpp/database/DatabaseManager.cpp
+++ b/cpp/database/DatabaseManager.cpp
@@ -29,4 +29,8 @@ void DatabaseManager::configureCredentials(
   }
 }
 
+void DatabaseManager::configureNetwork(const std::string& baseUrl, double timeoutMs) {
+  _network = NetworkConfig{baseUrl, timeoutMs};
+}
+
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/DatabaseManager.hpp
+++ b/cpp/database/DatabaseManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../credentials/CredentialProvider.hpp"
+#include "../http/NetworkConfig.hpp"
 #include "SQLiteConnection.hpp"
 #include <memory>
 #include <optional>
@@ -50,10 +51,19 @@ public:
     return *_credentials;
   }
 
+  void configureNetwork(const std::string& baseUrl, double timeoutMs);
+
+  const NetworkConfig& network() const {
+    if (!_network)
+      throw std::runtime_error("Database.configure() was not called with 'baseUrl'/'network' — sync is unavailable.");
+    return *_network;
+  }
+
 private:
   DatabaseManager() = default;
   std::shared_ptr<SQLiteConnection> _db;
   std::unique_ptr<CredentialProvider> _credentials;
+  std::optional<NetworkConfig> _network;
 };
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/HybridSalveDatabase.cpp
+++ b/cpp/database/HybridSalveDatabase.cpp
@@ -8,10 +8,11 @@ namespace margelo::nitro::salvedb {
 void HybridSalveDatabase::configure(const ConfigureParams& params) {
   if (params.name.empty())
     throw std::runtime_error("Database.configure: 'name' is required");
-  DatabaseManager::shared().open(params.name);
-
   if (params.baseUrl.has_value() != params.network.has_value())
     throw std::runtime_error("Database.configure: 'baseUrl' and 'network' must be provided together");
+
+  DatabaseManager::shared().open(params.name);
+
   if (params.baseUrl.has_value())
     DatabaseManager::shared().configureNetwork(*params.baseUrl, params.network->timeout);
 

--- a/cpp/database/HybridSalveDatabase.cpp
+++ b/cpp/database/HybridSalveDatabase.cpp
@@ -10,6 +10,11 @@ void HybridSalveDatabase::configure(const ConfigureParams& params) {
     throw std::runtime_error("Database.configure: 'name' is required");
   DatabaseManager::shared().open(params.name);
 
+  if (params.baseUrl.has_value() != params.network.has_value())
+    throw std::runtime_error("Database.configure: 'baseUrl' and 'network' must be provided together");
+  if (params.baseUrl.has_value())
+    DatabaseManager::shared().configureNetwork(*params.baseUrl, params.network->timeout);
+
   if (params.credentials.has_value()) {
     const auto& creds = *params.credentials;
     std::optional<InitialCredentialTokens> initialTokens;

--- a/cpp/http/CredentialHttpCaller.cpp
+++ b/cpp/http/CredentialHttpCaller.cpp
@@ -1,0 +1,30 @@
+#include "CredentialHttpCaller.hpp"
+#include "HttpUrlBuilder.hpp"
+#include "../platform/platform.hpp"
+#include <stdexcept>
+#include <variant>
+
+namespace margelo::nitro::salvedb {
+
+CredentialProvider::HttpCaller CredentialHttpCaller::create(const NetworkConfig& network) {
+  return [network](const std::string& endpoint, const json::Value& requestBody) -> RefreshHttpResponse {
+    HttpRequest request{
+      HttpMethod::Post,
+      HttpUrlBuilder::build(network.baseUrl, endpoint),
+      {{"Content-Type", "application/json"}},
+      json::stringify(requestBody),
+      network.timeoutMs
+    };
+
+    HttpOutcome outcome = platform::httpExecute(request);
+
+    if (auto* error = std::get_if<HttpNetworkError>(&outcome)) {
+      throw std::runtime_error("CredentialHttpCaller: refresh request failed — " + error->message);
+    }
+
+    const auto& response = std::get<HttpResponse>(outcome);
+    return RefreshHttpResponse{response.statusCode, json::parse(response.body)};
+  };
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/http/CredentialHttpCaller.cpp
+++ b/cpp/http/CredentialHttpCaller.cpp
@@ -23,7 +23,14 @@ CredentialProvider::HttpCaller CredentialHttpCaller::create(const NetworkConfig&
     }
 
     const auto& response = std::get<HttpResponse>(outcome);
-    return RefreshHttpResponse{response.statusCode, json::parse(response.body)};
+    try {
+      return RefreshHttpResponse{response.statusCode, json::parse(response.body)};
+    } catch (const std::exception& e) {
+      throw std::runtime_error(
+        "CredentialHttpCaller: failed to parse response body (status " +
+        std::to_string(response.statusCode) + ") — " + e.what()
+      );
+    }
   };
 }
 

--- a/cpp/http/CredentialHttpCaller.hpp
+++ b/cpp/http/CredentialHttpCaller.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../credentials/CredentialProvider.hpp"
+#include "NetworkConfig.hpp"
+
+namespace margelo::nitro::salvedb {
+
+class CredentialHttpCaller {
+public:
+  // Builds a CredentialProvider::HttpCaller backed by the real HTTP client.
+  // POST + Content-Type: application/json — the only shape refresh() sends.
+  static CredentialProvider::HttpCaller create(const NetworkConfig& network);
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/http/HttpTypes.hpp
+++ b/cpp/http/HttpTypes.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace margelo::nitro::salvedb {
+
+enum class HttpMethod { Get, Post, Put, Patch, Delete };
+
+// Ordered, allows duplicate keys — matches how HTTP headers behave on the wire.
+using HttpHeaders = std::vector<std::pair<std::string, std::string>>;
+
+struct HttpRequest {
+  HttpMethod method;
+  std::string url;
+  HttpHeaders headers;
+  std::optional<std::string> body;
+  double timeoutMs;
+};
+
+// Any completed exchange, including 4xx/5xx — status interpretation is the caller's job.
+struct HttpResponse {
+  int statusCode;
+  HttpHeaders headers;
+  std::string body;
+};
+
+enum class HttpNetworkErrorKind { Timeout, NoConnection, Cancelled, Other };
+
+// Transport-level failure — no response was received.
+struct HttpNetworkError {
+  HttpNetworkErrorKind kind;
+  std::string message;
+};
+
+using HttpOutcome = std::variant<HttpResponse, HttpNetworkError>;
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/http/HttpUrlBuilder.cpp
+++ b/cpp/http/HttpUrlBuilder.cpp
@@ -4,7 +4,7 @@ namespace margelo::nitro::salvedb {
 
 std::string HttpUrlBuilder::build(const std::string& baseUrl, const std::string& path) {
   std::string base = baseUrl;
-  if (!base.empty() && base.back() == '/') {
+  while (!base.empty() && base.back() == '/') {
     base.pop_back();
   }
 

--- a/cpp/http/HttpUrlBuilder.cpp
+++ b/cpp/http/HttpUrlBuilder.cpp
@@ -1,0 +1,21 @@
+#include "HttpUrlBuilder.hpp"
+
+namespace margelo::nitro::salvedb {
+
+std::string HttpUrlBuilder::build(const std::string& baseUrl, const std::string& path) {
+  std::string base = baseUrl;
+  if (!base.empty() && base.back() == '/') {
+    base.pop_back();
+  }
+
+  if (path.empty()) {
+    return base;
+  }
+
+  if (path.front() == '/') {
+    return base + path;
+  }
+  return base + "/" + path;
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/http/HttpUrlBuilder.hpp
+++ b/cpp/http/HttpUrlBuilder.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace margelo::nitro::salvedb {
+
+class HttpUrlBuilder {
+public:
+  static std::string build(const std::string& baseUrl, const std::string& path);
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/http/NetworkConfig.hpp
+++ b/cpp/http/NetworkConfig.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace margelo::nitro::salvedb {
+
+struct NetworkConfig {
+  std::string baseUrl;
+  double timeoutMs;
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/platform/platform.hpp
+++ b/cpp/platform/platform.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../http/HttpTypes.hpp"
 #include <optional>
 #include <string>
 
@@ -20,5 +21,10 @@ void setDocumentsDirectory(const std::string& path);
 void setSecureValue(const std::string& key, const std::string& value);
 std::optional<std::string> getSecureValue(const std::string& key);
 void deleteSecureValue(const std::string& key);
+
+// Executes an HTTP request and blocks the calling thread until it completes.
+// Same discipline as the functions above: only call from a native background
+// thread (e.g. inside Promise<T>::async), never from the JS thread.
+HttpOutcome httpExecute(const HttpRequest& request);
 
 } // namespace margelo::nitro::salvedb::platform

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -119,6 +119,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/expression/RequestExpressionEvaluator.cpp"
   "${PROJECT_CPP_DIR}/expression/JsonPathExtractor.cpp"
   "${PROJECT_CPP_DIR}/credentials/CredentialProvider.cpp"
+  "${PROJECT_CPP_DIR}/http/HttpUrlBuilder.cpp"
   "${PROJECT_CPP_DIR}/third_party/sqlite3/sqlite3.c"
   "${GENERATED_CPP_DIR}/HybridSalveDatabaseSpec.cpp"
 )
@@ -132,6 +133,7 @@ file(GLOB_RECURSE TEST_SOURCES
   "${CMAKE_SOURCE_DIR}/sync/*.cpp"
   "${CMAKE_SOURCE_DIR}/expression/*.cpp"
   "${CMAKE_SOURCE_DIR}/credentials/*.cpp"
+  "${CMAKE_SOURCE_DIR}/http/*.cpp"
 )
 
 # ── Real test suite: Catch2 + HybridSalveDatabase through real JSI ─────────
@@ -149,6 +151,8 @@ target_include_directories(salvedb_tests PRIVATE
   "${PROJECT_CPP_DIR}/query"
   "${PROJECT_CPP_DIR}/sync"
   "${PROJECT_CPP_DIR}/expression"
+  "${PROJECT_CPP_DIR}/credentials"
+  "${PROJECT_CPP_DIR}/http"
   "${PROJECT_CPP_DIR}/third_party/sqlite3"
   "${GENERATED_CPP_DIR}"
 )

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -120,6 +120,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/expression/JsonPathExtractor.cpp"
   "${PROJECT_CPP_DIR}/credentials/CredentialProvider.cpp"
   "${PROJECT_CPP_DIR}/http/HttpUrlBuilder.cpp"
+  "${PROJECT_CPP_DIR}/http/CredentialHttpCaller.cpp"
   "${PROJECT_CPP_DIR}/third_party/sqlite3/sqlite3.c"
   "${GENERATED_CPP_DIR}/HybridSalveDatabaseSpec.cpp"
 )

--- a/cpp/tests/database/HybridSalveDatabaseNetworkTests.cpp
+++ b/cpp/tests/database/HybridSalveDatabaseNetworkTests.cpp
@@ -52,3 +52,20 @@ TEST_CASE("configure() throws when only network is provided", "[database][networ
     network: { timeout: 8000 }
   }))"));
 }
+
+TEST_CASE("configure() validates baseUrl/network before opening the database", "[database][network]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  harness.run("db.configure({ name: '" + uniqueDbName("network_ordering_good") + "' })");
+  auto connectionBefore = DatabaseManager::shared().connection();
+
+  // A bad baseUrl/network pairing must throw before open() switches the
+  // connection to the new (differently-named) database.
+  REQUIRE_THROWS(harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("network_ordering_bad") + R"(',
+    baseUrl: 'https://api.company.com'
+  }))"));
+
+  REQUIRE(DatabaseManager::shared().connection() == connectionBefore);
+}

--- a/cpp/tests/database/HybridSalveDatabaseNetworkTests.cpp
+++ b/cpp/tests/database/HybridSalveDatabaseNetworkTests.cpp
@@ -1,0 +1,54 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/DatabaseManager.hpp"
+#include "../support/HybridDatabaseHarness.hpp"
+
+using margelo::nitro::salvedb::DatabaseManager;
+using margelo::nitro::salvedb::tests::HybridDatabaseHarness;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+void createDb(HybridDatabaseHarness& harness) {
+  harness.run("(() => { globalThis.db = globalThis.NitroModulesProxy.createHybridObject('SalveDatabase'); return true; })()");
+}
+
+} // namespace
+
+TEST_CASE("configure() with baseUrl and network populates DatabaseManager's NetworkConfig", "[database][network]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("network") + R"(',
+    baseUrl: 'https://api.company.com',
+    network: { timeout: 8000 }
+  }))");
+
+  const auto& network = DatabaseManager::shared().network();
+  REQUIRE(network.baseUrl == "https://api.company.com");
+  REQUIRE(network.timeoutMs == 8000.0);
+}
+
+TEST_CASE("configure() throws when only baseUrl is provided", "[database][network]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  REQUIRE_THROWS(harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("network_partial_a") + R"(',
+    baseUrl: 'https://api.company.com'
+  }))"));
+}
+
+TEST_CASE("configure() throws when only network is provided", "[database][network]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  REQUIRE_THROWS(harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("network_partial_b") + R"(',
+    network: { timeout: 8000 }
+  }))"));
+}

--- a/cpp/tests/http/CredentialHttpCallerTests.cpp
+++ b/cpp/tests/http/CredentialHttpCallerTests.cpp
@@ -1,0 +1,64 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../http/CredentialHttpCaller.hpp"
+#include "../support/platform_test.hpp"
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+NetworkConfig testNetwork() {
+  return NetworkConfig{"https://api.company.com", 5000.0};
+}
+
+} // namespace
+
+TEST_CASE("builds the request URL, method and Content-Type from NetworkConfig", "[http][CredentialHttpCaller]") {
+  HttpRequest captured;
+  platform::test::setHttpExecuteResult([&](const HttpRequest& request) -> HttpOutcome {
+    captured = request;
+    return HttpResponse{200, {}, R"({"accessToken": "a", "refreshToken": "r"})"};
+  });
+
+  auto caller = CredentialHttpCaller::create(testNetwork());
+  caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})"));
+
+  REQUIRE(captured.method == HttpMethod::Post);
+  REQUIRE(captured.url == "https://api.company.com/auth/refresh");
+  REQUIRE(captured.timeoutMs == 5000.0);
+  REQUIRE(captured.headers.size() == 1);
+  REQUIRE(captured.headers[0] == std::make_pair(std::string("Content-Type"), std::string("application/json")));
+  REQUIRE(captured.body.has_value());
+  REQUIRE(json::parse(*captured.body).getString("refreshToken") == "old");
+}
+
+TEST_CASE("returns a RefreshHttpResponse with the parsed body on success", "[http][CredentialHttpCaller]") {
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{200, {}, R"({"accessToken": "new-access", "refreshToken": "new-refresh"})"};
+  });
+
+  auto caller = CredentialHttpCaller::create(testNetwork());
+  auto response = caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})"));
+
+  REQUIRE(response.statusCode == 200);
+  REQUIRE(response.body.getString("accessToken") == "new-access");
+}
+
+TEST_CASE("propagates a non-2xx status as a RefreshHttpResponse, not an exception", "[http][CredentialHttpCaller]") {
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{401, {}, R"({"error": "invalid refresh token"})"};
+  });
+
+  auto caller = CredentialHttpCaller::create(testNetwork());
+  auto response = caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})"));
+
+  REQUIRE(response.statusCode == 401);
+}
+
+TEST_CASE("throws when the transport fails with a network error", "[http][CredentialHttpCaller]") {
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpNetworkError{HttpNetworkErrorKind::NoConnection, "no connection"};
+  });
+
+  auto caller = CredentialHttpCaller::create(testNetwork());
+  REQUIRE_THROWS_AS(caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})")), std::runtime_error);
+}

--- a/cpp/tests/http/CredentialHttpCallerTests.cpp
+++ b/cpp/tests/http/CredentialHttpCallerTests.cpp
@@ -62,3 +62,21 @@ TEST_CASE("throws when the transport fails with a network error", "[http][Creden
   auto caller = CredentialHttpCaller::create(testNetwork());
   REQUIRE_THROWS_AS(caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})")), std::runtime_error);
 }
+
+TEST_CASE("throws a clear error when a non-2xx response has a non-JSON body", "[http][CredentialHttpCaller]") {
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{500, {}, "<html>Internal Server Error</html>"};
+  });
+
+  auto caller = CredentialHttpCaller::create(testNetwork());
+  REQUIRE_THROWS_AS(caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})")), std::runtime_error);
+}
+
+TEST_CASE("throws a clear error when a non-2xx response has an empty body", "[http][CredentialHttpCaller]") {
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{502, {}, ""};
+  });
+
+  auto caller = CredentialHttpCaller::create(testNetwork());
+  REQUIRE_THROWS_AS(caller("/auth/refresh", json::parse(R"({"refreshToken": "old"})")), std::runtime_error);
+}

--- a/cpp/tests/http/HttpUrlBuilderTests.cpp
+++ b/cpp/tests/http/HttpUrlBuilderTests.cpp
@@ -27,3 +27,8 @@ TEST_CASE("returns baseUrl unchanged for an empty path", "[http][HttpUrlBuilder]
 TEST_CASE("preserves nested paths", "[http][HttpUrlBuilder]") {
   REQUIRE(HttpUrlBuilder::build("https://api.company.com", "/v1/customers/42") == "https://api.company.com/v1/customers/42");
 }
+
+TEST_CASE("collapses multiple trailing slashes on baseUrl", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com//", "/customers") == "https://api.company.com/customers");
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com///", "customers") == "https://api.company.com/customers");
+}

--- a/cpp/tests/http/HttpUrlBuilderTests.cpp
+++ b/cpp/tests/http/HttpUrlBuilderTests.cpp
@@ -1,0 +1,29 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../http/HttpUrlBuilder.hpp"
+
+using namespace margelo::nitro::salvedb;
+
+TEST_CASE("joins baseUrl without trailing slash and path with leading slash", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com", "/customers") == "https://api.company.com/customers");
+}
+
+TEST_CASE("collapses a doubled slash when both sides have one", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com/", "/customers") == "https://api.company.com/customers");
+}
+
+TEST_CASE("inserts a slash when neither side has one", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com", "customers") == "https://api.company.com/customers");
+}
+
+TEST_CASE("joins baseUrl with trailing slash and path without leading slash", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com/", "customers") == "https://api.company.com/customers");
+}
+
+TEST_CASE("returns baseUrl unchanged for an empty path", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com", "") == "https://api.company.com");
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com/", "") == "https://api.company.com");
+}
+
+TEST_CASE("preserves nested paths", "[http][HttpUrlBuilder]") {
+  REQUIRE(HttpUrlBuilder::build("https://api.company.com", "/v1/customers/42") == "https://api.company.com/v1/customers/42");
+}

--- a/cpp/tests/support/platform_test.cpp
+++ b/cpp/tests/support/platform_test.cpp
@@ -1,4 +1,5 @@
 #include "../../platform/platform.hpp"
+#include "platform_test.hpp"
 #include <cstdlib>
 #include <stdexcept>
 #include <unistd.h>
@@ -43,6 +44,30 @@ std::optional<std::string> getSecureValue(const std::string& key) {
 
 void deleteSecureValue(const std::string& key) {
   secureStore().erase(key);
+}
+
+// Host test double for httpExecute: no real network, tests configure the
+// outcome via platform::test::setHttpExecuteResult before calling code
+// under test.
+namespace {
+std::function<HttpOutcome(const HttpRequest&)>& httpExecuteHandler() {
+  static std::function<HttpOutcome(const HttpRequest&)> handler;
+  return handler;
+}
+} // namespace
+
+namespace test {
+void setHttpExecuteResult(std::function<HttpOutcome(const HttpRequest&)> handler) {
+  httpExecuteHandler() = std::move(handler);
+}
+} // namespace test
+
+HttpOutcome httpExecute(const HttpRequest& request) {
+  auto& handler = httpExecuteHandler();
+  if (!handler) {
+    throw std::runtime_error("platform_test: httpExecute called without platform::test::setHttpExecuteResult configured");
+  }
+  return handler(request);
 }
 
 } // namespace margelo::nitro::salvedb::platform

--- a/cpp/tests/support/platform_test.hpp
+++ b/cpp/tests/support/platform_test.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../../http/HttpTypes.hpp"
+#include <functional>
+
+namespace margelo::nitro::salvedb::platform::test {
+
+// Test-only hook: configures what httpExecute() returns. Must be set before
+// code under test calls platform::httpExecute.
+void setHttpExecuteResult(std::function<HttpOutcome(const HttpRequest&)> handler);
+
+} // namespace margelo::nitro::salvedb::platform::test

--- a/docs/native-layer.md
+++ b/docs/native-layer.md
@@ -25,31 +25,30 @@ The core logic (sync queue, expression interpreter, conflict resolution) has no 
 
 ## Contract pattern
 
-The C++ core defines interfaces (pure virtual classes). Each platform injects its own implementation at startup.
+The C++ core declares free functions in `namespace platform` (`cpp/platform/platform.hpp`) — not virtual classes, since each build is single-platform and there's no runtime polymorphism to gain. Each platform links its own implementation (`ios/SalveDbPlatform.mm` / `PlatformHttp.mm`, `android/src/main/cpp/platform_android*.cpp`) at build time. The C++ host test suite (`cpp/tests`) links a third implementation, `platform_test.cpp`, as a fake.
 
 ```cpp
-// C++ — defines the contract, knows nothing about the platform
+// C++ — cpp/platform/platform.hpp, no platform dependency
+namespace margelo::nitro::salvedb::platform {
+
+std::string getSecureValue(const std::string& key);
+void setSecureValue(const std::string& key, const std::string& value);
+
+// Blocks the calling thread until the request completes — only call from a
+// native background thread (e.g. inside Promise<T>::async), never from JS.
+HttpOutcome httpExecute(const HttpRequest& request);
+
+} // namespace margelo::nitro::salvedb::platform
+```
+
+`IBackgroundScheduler` below is still the planned shape for TASK-011 (not implemented yet) — it may end up following the same free-function pattern instead of a virtual class once that task starts, for consistency with `httpExecute`/credential storage.
+
+```cpp
 class IBackgroundScheduler {
 public:
     virtual void scheduleSync(int intervalSeconds) = 0;
     virtual void cancelSync() = 0;
     virtual ~IBackgroundScheduler() = default;
-};
-
-class IHttpClient {
-public:
-    virtual void post(const std::string& url,
-                      const std::string& body,
-                      std::function<void(int status, std::string response)> callback) = 0;
-    virtual ~IHttpClient() = default;
-};
-
-class ICredentialStore {
-public:
-    virtual std::string getAccessToken() = 0;
-    virtual std::string getRefreshToken() = 0;
-    virtual void save(const std::string& accessToken, const std::string& refreshToken) = 0;
-    virtual ~ICredentialStore() = default;
 };
 ```
 
@@ -94,12 +93,12 @@ C++ Core
   ├── MigrationEngine
   ├── ConflictResolver (lastWriteWins)
   └── SyncOrchestrator
-        ├── IBackgroundScheduler  ←──── Swift: BGTaskSchedulerAdapter
-        │                               Kotlin: WorkManagerAdapter
-        ├── IHttpClient           ←──── Swift: URLSessionAdapter
-        │                               Kotlin: OkHttpAdapter
-        └── ICredentialStore      ←──── Swift: KeychainAdapter
-                                        Kotlin: KeystoreAdapter
+        ├── IBackgroundScheduler   ←──── Swift: BGTaskSchedulerAdapter (not implemented yet, TASK-011)
+        │                                Kotlin: WorkManagerAdapter (not implemented yet, TASK-011)
+        ├── platform::httpExecute ←──── Swift: HttpAdapter (URLSession) + PlatformHttp.mm
+        │                                Kotlin: OkHttpAdapter + platform_android_http.cpp
+        └── platform::*SecureValue←──── Swift: SalveDbPlatform.mm (Keychain)
+                                         Kotlin: SalveDbSecureStorage.kt (Keystore)
 ```
 
 ---

--- a/ios/Http/HttpAdapter.swift
+++ b/ios/Http/HttpAdapter.swift
@@ -36,10 +36,10 @@ final class HttpAdapter {
         completion(.networkError(HttpNetworkError(kind: .other, message: "no HTTP response")))
         return
       }
-      guard let data = data, let body = String(data: data, encoding: .utf8) else {
-        completion(.networkError(HttpNetworkError(kind: .other, message: "response body is not valid UTF-8")))
-        return
-      }
+      // String(decoding:as:) never fails — invalid byte sequences become the
+      // replacement character — so a malformed body doesn't hide a completed
+      // HTTP exchange (status/headers) behind a network-error outcome.
+      let body = data.map { String(decoding: $0, as: UTF8.self) } ?? ""
 
       let headers = httpResponse.allHeaderFields.compactMap { key, value -> (name: String, value: String)? in
         guard let name = key as? String, let value = value as? String else { return nil }

--- a/ios/Http/HttpAdapter.swift
+++ b/ios/Http/HttpAdapter.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+final class HttpAdapter {
+  private let session: URLSession
+
+  init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  func execute(_ request: HttpRequest, completion: @escaping (HttpOutcome) -> Void) {
+    guard let url = URL(string: request.url) else {
+      completion(.networkError(HttpNetworkError(kind: .other, message: "invalid URL: \(request.url)")))
+      return
+    }
+
+    var urlRequest = URLRequest(url: url)
+    urlRequest.httpMethod = request.method.rawValue
+    urlRequest.timeoutInterval = request.timeoutMs / 1000
+    for header in request.headers {
+      urlRequest.addValue(header.value, forHTTPHeaderField: header.name)
+    }
+    if let body = request.body {
+      urlRequest.httpBody = body.data(using: .utf8)
+    }
+
+    let task = session.dataTask(with: urlRequest) { data, response, error in
+      if let urlError = error as? URLError {
+        completion(.networkError(HttpNetworkError(kind: .from(urlError), message: urlError.localizedDescription)))
+        return
+      }
+      if let error = error {
+        completion(.networkError(HttpNetworkError(kind: .other, message: error.localizedDescription)))
+        return
+      }
+      guard let httpResponse = response as? HTTPURLResponse else {
+        completion(.networkError(HttpNetworkError(kind: .other, message: "no HTTP response")))
+        return
+      }
+      guard let data = data, let body = String(data: data, encoding: .utf8) else {
+        completion(.networkError(HttpNetworkError(kind: .other, message: "response body is not valid UTF-8")))
+        return
+      }
+
+      let headers = httpResponse.allHeaderFields.compactMap { key, value -> (name: String, value: String)? in
+        guard let name = key as? String, let value = value as? String else { return nil }
+        return (name: name, value: value)
+      }
+      completion(.success(HttpResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)))
+    }
+    task.resume()
+  }
+}

--- a/ios/Http/HttpErrorKind+from.swift
+++ b/ios/Http/HttpErrorKind+from.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension HttpErrorKind {
+  static func from(_ error: URLError) -> HttpErrorKind {
+    switch error.code {
+    case .timedOut:
+      return .timeout
+    case .notConnectedToInternet, .cannotFindHost, .cannotConnectToHost, .networkConnectionLost, .dnsLookupFailed:
+      return .noConnection
+    case .cancelled:
+      return .cancelled
+    default:
+      return .other
+    }
+  }
+}

--- a/ios/Http/HttpErrorKind.swift
+++ b/ios/Http/HttpErrorKind.swift
@@ -1,0 +1,7 @@
+// Raw values match the string constants Android and C++ use for the same outcome.
+enum HttpErrorKind: String {
+  case timeout = "TIMEOUT"
+  case noConnection = "NO_CONNECTION"
+  case cancelled = "CANCELLED"
+  case other = "OTHER"
+}

--- a/ios/Http/HttpMethod.swift
+++ b/ios/Http/HttpMethod.swift
@@ -1,0 +1,7 @@
+enum HttpMethod: String {
+  case get = "GET"
+  case post = "POST"
+  case put = "PUT"
+  case patch = "PATCH"
+  case delete = "DELETE"
+}

--- a/ios/Http/HttpNetworkError.swift
+++ b/ios/Http/HttpNetworkError.swift
@@ -1,0 +1,4 @@
+struct HttpNetworkError {
+  let kind: HttpErrorKind
+  let message: String
+}

--- a/ios/Http/HttpOutcome.swift
+++ b/ios/Http/HttpOutcome.swift
@@ -1,0 +1,4 @@
+enum HttpOutcome {
+  case success(HttpResponse)
+  case networkError(HttpNetworkError)
+}

--- a/ios/Http/HttpRequest.swift
+++ b/ios/Http/HttpRequest.swift
@@ -1,0 +1,7 @@
+struct HttpRequest {
+  let method: HttpMethod
+  let url: String
+  let headers: [(name: String, value: String)]
+  let body: String?
+  let timeoutMs: Double
+}

--- a/ios/Http/HttpResponse.swift
+++ b/ios/Http/HttpResponse.swift
@@ -1,0 +1,5 @@
+struct HttpResponse {
+  let statusCode: Int
+  let headers: [(name: String, value: String)]
+  let body: String
+}

--- a/ios/Http/SalveDbHttpBridge.swift
+++ b/ios/Http/SalveDbHttpBridge.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+// ObjC-visible entry point for PlatformHttp.mm — HttpRequest/HttpOutcome
+// aren't representable in Objective-C, so this flattens to plain types.
+// `public` is required for the generated header to expose it (see
+// SalveDbHttpBridgeOutcome.swift).
+@objc(SalveDbHttpBridge) public final class SalveDbHttpBridge: NSObject {
+  private let adapter = HttpAdapter()
+
+  public override init() {}
+
+  @objc public func execute(
+    method: String,
+    url: String,
+    headerNames: [String],
+    headerValues: [String],
+    body: String?,
+    timeoutMs: Double,
+    completion: @escaping (SalveDbHttpBridgeOutcome) -> Void
+  ) {
+    guard let httpMethod = HttpMethod(rawValue: method) else {
+      completion(SalveDbHttpBridgeOutcome(
+        isSuccess: false, statusCode: 0, responseHeaderNames: [], responseHeaderValues: [],
+        responseBody: "", errorKind: "OTHER", errorMessage: "unknown HTTP method: \(method)"
+      ))
+      return
+    }
+
+    let headerCount = min(headerNames.count, headerValues.count)
+    let headers = (0..<headerCount).map { (name: headerNames[$0], value: headerValues[$0]) }
+    let request = HttpRequest(method: httpMethod, url: url, headers: headers, body: body, timeoutMs: timeoutMs)
+
+    adapter.execute(request) { outcome in
+      completion(SalveDbHttpBridgeOutcome.from(outcome))
+    }
+  }
+}

--- a/ios/Http/SalveDbHttpBridgeOutcome.swift
+++ b/ios/Http/SalveDbHttpBridgeOutcome.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+// ObjC-visible marshaling type only — PlatformHttp.mm reads these plain
+// properties directly. `public` is required: with C++/ObjC interop mode
+// active in this module, internal (default) declarations don't reach the
+// generated header even within the same target.
+@objc(SalveDbHttpBridgeOutcome) public final class SalveDbHttpBridgeOutcome: NSObject {
+  @objc public let isSuccess: Bool
+  @objc public let statusCode: Int
+  @objc public let responseHeaderNames: [String]
+  @objc public let responseHeaderValues: [String]
+  @objc public let responseBody: String
+  @objc public let errorKind: String
+  @objc public let errorMessage: String
+
+  init(
+    isSuccess: Bool,
+    statusCode: Int,
+    responseHeaderNames: [String],
+    responseHeaderValues: [String],
+    responseBody: String,
+    errorKind: String,
+    errorMessage: String
+  ) {
+    self.isSuccess = isSuccess
+    self.statusCode = statusCode
+    self.responseHeaderNames = responseHeaderNames
+    self.responseHeaderValues = responseHeaderValues
+    self.responseBody = responseBody
+    self.errorKind = errorKind
+    self.errorMessage = errorMessage
+  }
+
+  static func from(_ outcome: HttpOutcome) -> SalveDbHttpBridgeOutcome {
+    switch outcome {
+    case .success(let response):
+      return SalveDbHttpBridgeOutcome(
+        isSuccess: true,
+        statusCode: response.statusCode,
+        responseHeaderNames: response.headers.map { $0.name },
+        responseHeaderValues: response.headers.map { $0.value },
+        responseBody: response.body,
+        errorKind: "",
+        errorMessage: ""
+      )
+    case .networkError(let error):
+      return SalveDbHttpBridgeOutcome(
+        isSuccess: false,
+        statusCode: 0,
+        responseHeaderNames: [],
+        responseHeaderValues: [],
+        responseBody: "",
+        errorKind: error.kind.rawValue,
+        errorMessage: error.message
+      )
+    }
+  }
+}

--- a/ios/PlatformHttp.mm
+++ b/ios/PlatformHttp.mm
@@ -34,18 +34,34 @@ HttpOutcome httpExecute(const HttpRequest& request) {
   NSMutableArray<NSString*>* headerNames = [NSMutableArray arrayWithCapacity:request.headers.size()];
   NSMutableArray<NSString*>* headerValues = [NSMutableArray arrayWithCapacity:request.headers.size()];
   for (const auto& [name, value] : request.headers) {
-    [headerNames addObject:[NSString stringWithUTF8String:name.c_str()]];
-    [headerValues addObject:[NSString stringWithUTF8String:value.c_str()]];
+    NSString* headerName = [NSString stringWithUTF8String:name.c_str()];
+    NSString* headerValue = [NSString stringWithUTF8String:value.c_str()];
+    if (headerName == nil || headerValue == nil) {
+      return HttpNetworkError{HttpNetworkErrorKind::Other, "invalid UTF-8 in request header"};
+    }
+    [headerNames addObject:headerName];
+    [headerValues addObject:headerValue];
   }
 
-  NSString* body = request.body.has_value() ? [NSString stringWithUTF8String:request.body->c_str()] : nil;
+  NSString* body = nil;
+  if (request.body.has_value()) {
+    body = [NSString stringWithUTF8String:request.body->c_str()];
+    if (body == nil) {
+      return HttpNetworkError{HttpNetworkErrorKind::Other, "invalid UTF-8 in request body"};
+    }
+  }
+
+  NSString* urlString = [NSString stringWithUTF8String:request.url.c_str()];
+  if (urlString == nil) {
+    return HttpNetworkError{HttpNetworkErrorKind::Other, "invalid UTF-8 in request URL"};
+  }
 
   __block SalveDbHttpBridgeOutcome* result = nil;
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
   SalveDbHttpBridge* bridge = [SalveDbHttpBridge new];
   [bridge executeWithMethod:[NSString stringWithUTF8String:methodName(request.method)]
-                         url:[NSString stringWithUTF8String:request.url.c_str()]
+                         url:urlString
                  headerNames:headerNames
                 headerValues:headerValues
                         body:body

--- a/ios/PlatformHttp.mm
+++ b/ios/PlatformHttp.mm
@@ -1,0 +1,73 @@
+#import "SalveDb-Swift.h"
+#include "../cpp/http/HttpTypes.hpp"
+#include "../cpp/platform/platform.hpp"
+#include <dispatch/dispatch.h>
+#include <stdexcept>
+
+namespace margelo::nitro::salvedb::platform {
+
+namespace {
+
+const char* methodName(HttpMethod method) {
+  switch (method) {
+    case HttpMethod::Get: return "GET";
+    case HttpMethod::Post: return "POST";
+    case HttpMethod::Put: return "PUT";
+    case HttpMethod::Patch: return "PATCH";
+    case HttpMethod::Delete: return "DELETE";
+  }
+  throw std::runtime_error("SalveDb: unknown HttpMethod");
+}
+
+HttpNetworkErrorKind parseErrorKind(NSString* kind) {
+  if ([kind isEqualToString:@"TIMEOUT"]) return HttpNetworkErrorKind::Timeout;
+  if ([kind isEqualToString:@"NO_CONNECTION"]) return HttpNetworkErrorKind::NoConnection;
+  if ([kind isEqualToString:@"CANCELLED"]) return HttpNetworkErrorKind::Cancelled;
+  return HttpNetworkErrorKind::Other;
+}
+
+} // namespace
+
+// Bridges the async Swift adapter to the synchronous platform::httpExecute
+// contract via a semaphore — only called off the main/JS thread.
+HttpOutcome httpExecute(const HttpRequest& request) {
+  NSMutableArray<NSString*>* headerNames = [NSMutableArray arrayWithCapacity:request.headers.size()];
+  NSMutableArray<NSString*>* headerValues = [NSMutableArray arrayWithCapacity:request.headers.size()];
+  for (const auto& [name, value] : request.headers) {
+    [headerNames addObject:[NSString stringWithUTF8String:name.c_str()]];
+    [headerValues addObject:[NSString stringWithUTF8String:value.c_str()]];
+  }
+
+  NSString* body = request.body.has_value() ? [NSString stringWithUTF8String:request.body->c_str()] : nil;
+
+  __block SalveDbHttpBridgeOutcome* result = nil;
+  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+  SalveDbHttpBridge* bridge = [SalveDbHttpBridge new];
+  [bridge executeWithMethod:[NSString stringWithUTF8String:methodName(request.method)]
+                         url:[NSString stringWithUTF8String:request.url.c_str()]
+                 headerNames:headerNames
+                headerValues:headerValues
+                        body:body
+                   timeoutMs:request.timeoutMs
+                  completion:^(SalveDbHttpBridgeOutcome* outcome) {
+                    result = outcome;
+                    dispatch_semaphore_signal(semaphore);
+                  }];
+
+  dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+
+  if (result.isSuccess) {
+    HttpHeaders headers;
+    NSUInteger count = MIN(result.responseHeaderNames.count, result.responseHeaderValues.count);
+    headers.reserve(count);
+    for (NSUInteger i = 0; i < count; i++) {
+      headers.emplace_back(result.responseHeaderNames[i].UTF8String, result.responseHeaderValues[i].UTF8String);
+    }
+    return HttpResponse{static_cast<int>(result.statusCode), std::move(headers), result.responseBody.UTF8String};
+  }
+
+  return HttpNetworkError{parseErrorKind(result.errorKind), result.errorMessage.UTF8String};
+}
+
+} // namespace margelo::nitro::salvedb::platform

--- a/ios/tests/HttpAdapterTests/Package.swift
+++ b/ios/tests/HttpAdapterTests/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+  name: "HttpAdapterTests",
+  platforms: [.macOS(.v13)],
+  targets: [
+    // Sources/SalveDbHttpCore/*.swift are symlinks to the production files in
+    // ios/Http/ — SwiftPM doesn't allow a target path outside the package root.
+    .target(name: "SalveDbHttpCore"),
+    .testTarget(name: "SalveDbHttpCoreTests", dependencies: ["SalveDbHttpCore"], path: "Tests/SalveDbHttpCoreTests"),
+  ]
+)

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpAdapter.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpAdapter.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpAdapter.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpErrorKind+from.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpErrorKind+from.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpErrorKind+from.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpErrorKind.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpErrorKind.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpErrorKind.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpMethod.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpMethod.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpMethod.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpNetworkError.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpNetworkError.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpNetworkError.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpOutcome.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpOutcome.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpOutcome.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpRequest.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpRequest.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpRequest.swift

--- a/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpResponse.swift
+++ b/ios/tests/HttpAdapterTests/Sources/SalveDbHttpCore/HttpResponse.swift
@@ -1,0 +1,1 @@
+../../../../Http/HttpResponse.swift

--- a/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/HttpAdapterTests.swift
+++ b/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/HttpAdapterTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import SalveDbHttpCore
+
+final class HttpAdapterTests: XCTestCase {
+
+  override func tearDown() {
+    StubURLProtocol.reset()
+    super.tearDown()
+  }
+
+  private func request(
+    method: HttpMethod = .get,
+    headers: [(name: String, value: String)] = [],
+    body: String? = nil,
+    timeoutMs: Double = 5000
+  ) -> HttpRequest {
+    HttpRequest(method: method, url: "https://example.com/path", headers: headers, body: body, timeoutMs: timeoutMs)
+  }
+
+  private func execute(_ request: HttpRequest) -> HttpOutcome {
+    let expectation = expectation(description: "completion")
+    var result: HttpOutcome?
+    HttpAdapter(session: StubURLProtocol.session()).execute(request) {
+      result = $0
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 2)
+    return result!
+  }
+
+  func testGetReturnsTheStubbedStatusAndBody() {
+    StubURLProtocol.handler = { _ in
+      (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+       "hello".data(using: .utf8)!)
+    }
+
+    guard case .success(let response) = execute(request()) else { return XCTFail("expected success") }
+    XCTAssertEqual(response.statusCode, 200)
+    XCTAssertEqual(response.body, "hello")
+  }
+
+  func testEachMethodSendsTheCorrectHTTPMethod() {
+    for method in [HttpMethod.get, .post, .put, .patch, .delete] {
+      var capturedMethod: String?
+      StubURLProtocol.handler = { req in
+        capturedMethod = req.httpMethod
+        return (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+      }
+
+      _ = execute(request(method: method))
+      XCTAssertEqual(capturedMethod, method.rawValue)
+    }
+  }
+
+  func testRequestBodyArrivesIntact() {
+    var capturedBody: Data?
+    StubURLProtocol.handler = { req in
+      capturedBody = req.httpBody ?? req.httpBodyStream.map { stream -> Data in
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 1024
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        while stream.hasBytesAvailable {
+          let read = stream.read(&buffer, maxLength: bufferSize)
+          if read > 0 { data.append(buffer, count: read) }
+        }
+        return data
+      }
+      return (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 201, httpVersion: nil, headerFields: nil)!, Data())
+    }
+
+    _ = execute(request(method: .post, body: #"{"a":1}"#))
+    XCTAssertEqual(capturedBody.flatMap { String(data: $0, encoding: .utf8) }, #"{"a":1}"#)
+  }
+
+  func testA500ResponseIsSuccessNotNetworkError() {
+    StubURLProtocol.handler = { _ in
+      (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 500, httpVersion: nil, headerFields: nil)!,
+       "boom".data(using: .utf8)!)
+    }
+
+    guard case .success(let response) = execute(request()) else { return XCTFail("expected success, not a network error") }
+    XCTAssertEqual(response.statusCode, 500)
+  }
+
+  func testATransportErrorIsANetworkError() {
+    StubURLProtocol.errorToThrow = URLError(.notConnectedToInternet)
+
+    guard case .networkError(let error) = execute(request()) else { return XCTFail("expected a network error") }
+    XCTAssertEqual(error.kind, .noConnection)
+  }
+
+  func testASlowResponseBeyondTheTimeoutProducesATimeoutError() {
+    StubURLProtocol.delay = 2
+    StubURLProtocol.handler = { _ in
+      (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+    }
+
+    guard case .networkError(let error) = execute(request(timeoutMs: 200)) else { return XCTFail("expected a timeout network error") }
+    XCTAssertEqual(error.kind, .timeout)
+  }
+
+  func testCustomHeadersAndAnAuthLikeHeaderCoexist() {
+    var capturedHeaders: [String: String] = [:]
+    StubURLProtocol.handler = { req in
+      capturedHeaders = req.allHTTPHeaderFields ?? [:]
+      return (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
+    }
+
+    _ = execute(request(headers: [(name: "X-Custom", value: "custom-value"), (name: "Authorization", value: "Bearer token")]))
+    XCTAssertEqual(capturedHeaders["X-Custom"], "custom-value")
+    XCTAssertEqual(capturedHeaders["Authorization"], "Bearer token")
+  }
+
+  func testResponseHeadersAreReturned() {
+    StubURLProtocol.handler = { _ in
+      (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: ["X-Reply": "value"])!, Data())
+    }
+
+    guard case .success(let response) = execute(request()) else { return XCTFail("expected success") }
+    XCTAssertTrue(response.headers.contains { $0.name == "X-Reply" && $0.value == "value" })
+  }
+}

--- a/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/HttpAdapterTests.swift
+++ b/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/HttpAdapterTests.swift
@@ -17,7 +17,7 @@ final class HttpAdapterTests: XCTestCase {
     HttpRequest(method: method, url: "https://example.com/path", headers: headers, body: body, timeoutMs: timeoutMs)
   }
 
-  private func execute(_ request: HttpRequest) -> HttpOutcome {
+  private func execute(_ request: HttpRequest) throws -> HttpOutcome {
     let expectation = expectation(description: "completion")
     var result: HttpOutcome?
     HttpAdapter(session: StubURLProtocol.session()).execute(request) {
@@ -25,21 +25,21 @@ final class HttpAdapterTests: XCTestCase {
       expectation.fulfill()
     }
     wait(for: [expectation], timeout: 2)
-    return result!
+    return try XCTUnwrap(result, "completion handler was never called")
   }
 
-  func testGetReturnsTheStubbedStatusAndBody() {
+  func testGetReturnsTheStubbedStatusAndBody() throws {
     StubURLProtocol.handler = { _ in
       (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
        "hello".data(using: .utf8)!)
     }
 
-    guard case .success(let response) = execute(request()) else { return XCTFail("expected success") }
+    guard case .success(let response) = try execute(request()) else { return XCTFail("expected success") }
     XCTAssertEqual(response.statusCode, 200)
     XCTAssertEqual(response.body, "hello")
   }
 
-  func testEachMethodSendsTheCorrectHTTPMethod() {
+  func testEachMethodSendsTheCorrectHTTPMethod() throws {
     for method in [HttpMethod.get, .post, .put, .patch, .delete] {
       var capturedMethod: String?
       StubURLProtocol.handler = { req in
@@ -47,12 +47,12 @@ final class HttpAdapterTests: XCTestCase {
         return (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
       }
 
-      _ = execute(request(method: method))
+      _ = try execute(request(method: method))
       XCTAssertEqual(capturedMethod, method.rawValue)
     }
   }
 
-  func testRequestBodyArrivesIntact() {
+  func testRequestBodyArrivesIntact() throws {
     var capturedBody: Data?
     StubURLProtocol.handler = { req in
       capturedBody = req.httpBody ?? req.httpBodyStream.map { stream -> Data in
@@ -70,55 +70,65 @@ final class HttpAdapterTests: XCTestCase {
       return (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 201, httpVersion: nil, headerFields: nil)!, Data())
     }
 
-    _ = execute(request(method: .post, body: #"{"a":1}"#))
+    _ = try execute(request(method: .post, body: #"{"a":1}"#))
     XCTAssertEqual(capturedBody.flatMap { String(data: $0, encoding: .utf8) }, #"{"a":1}"#)
   }
 
-  func testA500ResponseIsSuccessNotNetworkError() {
+  func testA500ResponseIsSuccessNotNetworkError() throws {
     StubURLProtocol.handler = { _ in
       (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 500, httpVersion: nil, headerFields: nil)!,
        "boom".data(using: .utf8)!)
     }
 
-    guard case .success(let response) = execute(request()) else { return XCTFail("expected success, not a network error") }
+    guard case .success(let response) = try execute(request()) else { return XCTFail("expected success, not a network error") }
     XCTAssertEqual(response.statusCode, 500)
   }
 
-  func testATransportErrorIsANetworkError() {
+  func testATransportErrorIsANetworkError() throws {
     StubURLProtocol.errorToThrow = URLError(.notConnectedToInternet)
 
-    guard case .networkError(let error) = execute(request()) else { return XCTFail("expected a network error") }
+    guard case .networkError(let error) = try execute(request()) else { return XCTFail("expected a network error") }
     XCTAssertEqual(error.kind, .noConnection)
   }
 
-  func testASlowResponseBeyondTheTimeoutProducesATimeoutError() {
+  func testASlowResponseBeyondTheTimeoutProducesATimeoutError() throws {
     StubURLProtocol.delay = 2
     StubURLProtocol.handler = { _ in
       (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
     }
 
-    guard case .networkError(let error) = execute(request(timeoutMs: 200)) else { return XCTFail("expected a timeout network error") }
+    guard case .networkError(let error) = try execute(request(timeoutMs: 200)) else { return XCTFail("expected a timeout network error") }
     XCTAssertEqual(error.kind, .timeout)
   }
 
-  func testCustomHeadersAndAnAuthLikeHeaderCoexist() {
+  func testCustomHeadersAndAnAuthLikeHeaderCoexist() throws {
     var capturedHeaders: [String: String] = [:]
     StubURLProtocol.handler = { req in
       capturedHeaders = req.allHTTPHeaderFields ?? [:]
       return (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!, Data())
     }
 
-    _ = execute(request(headers: [(name: "X-Custom", value: "custom-value"), (name: "Authorization", value: "Bearer token")]))
+    _ = try execute(request(headers: [(name: "X-Custom", value: "custom-value"), (name: "Authorization", value: "Bearer token")]))
     XCTAssertEqual(capturedHeaders["X-Custom"], "custom-value")
     XCTAssertEqual(capturedHeaders["Authorization"], "Bearer token")
   }
 
-  func testResponseHeadersAreReturned() {
+  func testResponseHeadersAreReturned() throws {
     StubURLProtocol.handler = { _ in
       (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: ["X-Reply": "value"])!, Data())
     }
 
-    guard case .success(let response) = execute(request()) else { return XCTFail("expected success") }
+    guard case .success(let response) = try execute(request()) else { return XCTFail("expected success") }
     XCTAssertTrue(response.headers.contains { $0.name == "X-Reply" && $0.value == "value" })
+  }
+
+  func testNonUTF8BodyIsDecodedLenientlyWithoutLosingTheStatus() throws {
+    StubURLProtocol.handler = { _ in
+      (HTTPURLResponse(url: URL(string: "https://example.com/path")!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+       Data([0xFF, 0xFE, 0xFD]))
+    }
+
+    guard case .success(let response) = try execute(request()) else { return XCTFail("expected success, not a network error") }
+    XCTAssertEqual(response.statusCode, 200)
   }
 }

--- a/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/StubURLProtocol.swift
+++ b/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/StubURLProtocol.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+final class StubURLProtocol: URLProtocol {
+  static var handler: ((URLRequest) -> (HTTPURLResponse, Data)?)?
+  static var errorToThrow: Error?
+  static var delay: TimeInterval = 0
+
+  private var isCancelled = false
+
+  override static func canInit(with request: URLRequest) -> Bool { true }
+  override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    if let error = StubURLProtocol.errorToThrow {
+      client?.urlProtocol(self, didFailWithError: error)
+      return
+    }
+    guard let (response, data) = StubURLProtocol.handler?(request) else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
+    DispatchQueue.global().asyncAfter(deadline: .now() + StubURLProtocol.delay) { [client, self] in
+      guard !isCancelled else { return }
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    }
+  }
+
+  override func stopLoading() {
+    isCancelled = true
+  }
+
+  static func session() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  static func reset() {
+    handler = nil
+    errorToThrow = nil
+    delay = 0
+  }
+}

--- a/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/StubURLProtocol.swift
+++ b/ios/tests/HttpAdapterTests/Tests/SalveDbHttpCoreTests/StubURLProtocol.swift
@@ -5,7 +5,12 @@ final class StubURLProtocol: URLProtocol {
   static var errorToThrow: Error?
   static var delay: TimeInterval = 0
 
-  private var isCancelled = false
+  private let lock = NSLock()
+  private var _isCancelled = false
+  private var isCancelled: Bool {
+    get { lock.withLock { _isCancelled } }
+    set { lock.withLock { _isCancelled = newValue } }
+  }
 
   override static func canInit(with request: URLRequest) -> Bool { true }
   override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest",
     "test:native": "bash cpp/tests/run.sh",
     "test:native:android": "cd example/android && ./gradlew :salve-software_react-native-salve-db:testDebugUnitTest",
+    "test:native:ios": "swift test --package-path ios/tests/HttpAdapterTests",
     "typecheck": "tsc --noEmit",
     "clean": "git clean -dfX",
     "release": "semantic-release",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "jest",
     "test:native": "bash cpp/tests/run.sh",
+    "test:native:android": "cd example/android && ./gradlew :salve-software_react-native-salve-db:testDebugUnitTest",
     "typecheck": "tsc --noEmit",
     "clean": "git clean -dfX",
     "release": "semantic-release",


### PR DESCRIPTION
## Summary

Implements TASK-010 — native HTTP client for Android (OkHttp) and iOS (URLSession), from scratch on top of current `develop` (not the earlier `feat/http-client` branch, which was abandoned as a merge base since it predated the real `CredentialProvider` from TASK-009 — see discussion on #11).

- **C++**: `platform::httpExecute(request)` — a synchronous free function in `namespace platform` (same pattern as `setSecureValue`/`getSecureValue`), not a virtual class. `HttpOutcome = variant<HttpResponse, HttpNetworkError>` distinguishes transport failure from any HTTP status (incl. 4xx/5xx). `HttpUrlBuilder` normalizes `baseUrl`+`path`. `NetworkConfig` is a plain value type held by `DatabaseManager` (no singleton). `configure()` now wires `baseUrl`/`network.timeout` instead of discarding them.
- **The missing piece from TASK-009**: `CredentialHttpCaller` adapts `platform::httpExecute` (async-shaped by design, sync by contract) into `CredentialProvider::HttpCaller` (already in `develop`, sync, `json::Value`-based) — a factory ready for whoever implements TASK-012 to plug into `CredentialProvider::refresh()`. Not wired to any production call site here (out of scope).
- **Android**: `OkHttpAdapter` (pure Kotlin core, testable without JNI) + JNI bridge (`platform_android_http.cpp` / `SalveDbHttpClient.kt`), reusing extracted `JniSupport` helpers (`ScopedJNIEnv`, exception/class-caching) shared with the existing credential-storage bridge.
- **iOS**: `HttpAdapter` (pure Swift core, `URLSessionDataTask` + completion handler, no async/await) + `PlatformHttp.mm` (semaphore-based sync bridge) + a small `@objc` marshaling layer (`SalveDbHttpBridge`/`SalveDbHttpBridgeOutcome`) since `HttpRequest`/`HttpOutcome` aren't ObjC-representable. First Swift code in the module.
- **Tests**: C++ via the existing Catch2 harness (`npm run test:native`, extended `platform_test.cpp` with an injectable `httpExecute` fake), Android via new `android/src/test` + JUnit/MockWebServer (`npm run test:native:android`, source set didn't exist before), iOS via a new standalone Swift Package (`npm run test:native:ios`, `StubURLProtocol`, no Xcode/XCTest target needed — mirrors `cpp/tests`' philosophy).

## Bugs found and fixed along the way (verified via real builds, not just unit tests)

- OkHttp's own `callTimeout` cancels the call internally when it fires, so `call.isCanceled()` is `true` for both a real cancel and a timeout — error-kind classification had to check the exception shape (`SocketTimeoutException`/`InterruptedIOException("timeout")`) before `isCanceled()`, not after.
- This module builds with `-cxx-interoperability-mode` enabled, under which the generated `SalveDb-Swift.h` only exposes `public` Swift declarations — `internal` (the default) silently doesn't reach the header even within the same target. The ObjC-visible bridge types needed explicit `public` before `PlatformHttp.mm` could see them at all.
- `SalveDb.podspec`'s `exclude_files` only excluded `cpp/tests/**/*`; the new `ios/tests/**/*` SPM package (symlinked sources + real test files) would otherwise have been pulled into the production pod.
- `ios/tests/` had stale untracked `.build/` artifacts (including a generated `.swift` file) left over from an earlier, unrelated branch — these would have polluted the podspec's `ios/**/*.swift` glob; cleaned up and gitignored.

## Test plan

- [x] `npm run test:native` — 218 assertions, 82 test cases, all passing
- [x] `npm run test:native:android` — 10 tests passing (new source set)
- [x] `npm run test:native:ios` — 8 tests passing (new standalone SPM package)
- [x] Real Android build (`:app:assembleDebug`)
- [x] Real iOS build (`pod install` + `xcodebuild`, clean and incremental)

## Out of scope (unchanged from the original task doc)

Body content/response extraction semantics (TASK-008). Retry policy (TASK-012). `SyncOrchestrator` wiring — `CredentialHttpCaller::create()` is ready but nothing calls `CredentialProvider::refresh()` in production yet; that's TASK-012's job.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable network access with base URL and request timeouts.
  * Added cross-platform HTTP support for GET, POST, PUT, PATCH, and DELETE requests.
  * Added response headers, request bodies, and network error reporting.
  * Added automatic credential refresh through the configured authentication endpoint.
* **Bug Fixes**
  * Improved URL joining, timeout handling, connectivity detection, and cancellation reporting.
* **Documentation**
  * Updated native architecture documentation to reflect the HTTP platform integration.
* **Tests**
  * Added comprehensive Android, iOS, and native HTTP integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->