### PR TITLE
fix(native): route error logs through platform log channel

### DIFF
--- a/android/src/main/cpp/platform_android.cpp
+++ b/android/src/main/cpp/platform_android.cpp
@@ -2,11 +2,15 @@
 #include "../../../../cpp/platform/platform_android_jni.hpp"
 #include "JniSupport.hpp"
 #include "platform_android_http.hpp"
-#include <iostream>
+#include <android/log.h>
 #include <stdexcept>
 #include <string>
 
 namespace margelo::nitro::salvedb::platform {
+
+void logError(const std::string& tag, const std::string& message) noexcept {
+  __android_log_print(ANDROID_LOG_ERROR, tag.c_str(), "%s", message.c_str());
+}
 
 static std::string s_documentsDirectory;
 static jclass s_secureStorageClass = nullptr;
@@ -97,7 +101,7 @@ void deleteSecureValue(const std::string& key) {
 
 void scheduleBackgroundSync() noexcept {
   if (!s_backgroundSchedulerClass) {
-    std::cerr << "SalveDb: scheduleBackgroundSync skipped, SalveDbBackgroundScheduler class was not resolved" << std::endl;
+    logError("SalveDb", "scheduleBackgroundSync skipped, SalveDbBackgroundScheduler class was not resolved");
     return;
   }
 
@@ -106,14 +110,14 @@ void scheduleBackgroundSync() noexcept {
 
   jmethodID mid = env->GetStaticMethodID(s_backgroundSchedulerClass, "scheduleFromNative", "()V");
   if (!mid) {
-    std::cerr << "SalveDb: scheduleBackgroundSync failed, SalveDbBackgroundScheduler.scheduleFromNative lookup failed — will retry on next process start" << std::endl;
+    logError("SalveDb", "scheduleBackgroundSync failed, SalveDbBackgroundScheduler.scheduleFromNative lookup failed — will retry on next process start");
     env->ExceptionClear();
     return;
   }
 
   env->CallStaticVoidMethod(s_backgroundSchedulerClass, mid);
   if (env->ExceptionCheck()) {
-    std::cerr << "SalveDb: scheduleBackgroundSync failed, SalveDbBackgroundScheduler.scheduleFromNative threw — will retry on next process start" << std::endl;
+    logError("SalveDb", "scheduleBackgroundSync failed, SalveDbBackgroundScheduler.scheduleFromNative threw — will retry on next process start");
     env->ExceptionClear();
   }
 }

--- a/cpp/platform/platform.hpp
+++ b/cpp/platform/platform.hpp
@@ -32,4 +32,9 @@ void scheduleBackgroundSync() noexcept;
 // thread (e.g. inside Promise<T>::async), never from the JS thread.
 HttpOutcome httpExecute(const HttpRequest& request);
 
+// Logs a diagnostic message through the platform's native logging channel.
+// Android: __android_log_print (plain std::cerr never reaches logcat).
+// iOS: NSLog. Tests: std::cerr.
+void logError(const std::string& tag, const std::string& message) noexcept;
+
 } // namespace margelo::nitro::salvedb::platform

--- a/cpp/sync/SyncNativeEntryPoint.cpp
+++ b/cpp/sync/SyncNativeEntryPoint.cpp
@@ -1,23 +1,23 @@
 #include "SyncNativeEntryPoint.hpp"
 #include "SyncOrchestrator.hpp"
 #include "../database/DatabaseManager.hpp"
+#include "../platform/platform.hpp"
 #include <exception>
-#include <iostream>
 
 namespace margelo::nitro::salvedb {
 
 void triggerSyncAllFromNative() {
   if (!DatabaseManager::shared().isOpen()) {
-    std::cerr << "SyncNativeEntryPoint: database not configured yet, skipping" << std::endl;
+    platform::logError("SalveDb", "SyncNativeEntryPoint: database not configured yet, skipping");
     return;
   }
 
   try {
     SyncOrchestrator().triggerSyncAll(/*discardIfBusy*/ true);
   } catch (const std::exception& e) {
-    std::cerr << "SyncNativeEntryPoint: triggerSyncAllFromNative failed: " << e.what() << std::endl;
+    platform::logError("SalveDb", std::string("SyncNativeEntryPoint: triggerSyncAllFromNative failed: ") + e.what());
   } catch (...) {
-    std::cerr << "SyncNativeEntryPoint: triggerSyncAllFromNative failed with an unknown exception" << std::endl;
+    platform::logError("SalveDb", "SyncNativeEntryPoint: triggerSyncAllFromNative failed with an unknown exception");
   }
 }
 
@@ -26,15 +26,15 @@ void wakeBackgroundSyncFromNative() {
   try {
     ready = DatabaseManager::shared().reopenFromPersistedConfigIfNeeded();
   } catch (const std::exception& e) {
-    std::cerr << "SyncNativeEntryPoint: wakeBackgroundSyncFromNative failed to rehydrate: " << e.what() << std::endl;
+    platform::logError("SalveDb", std::string("SyncNativeEntryPoint: wakeBackgroundSyncFromNative failed to rehydrate: ") + e.what());
     return;
   } catch (...) {
-    std::cerr << "SyncNativeEntryPoint: wakeBackgroundSyncFromNative failed to rehydrate with an unknown exception" << std::endl;
+    platform::logError("SalveDb", "SyncNativeEntryPoint: wakeBackgroundSyncFromNative failed to rehydrate with an unknown exception");
     return;
   }
 
   if (!ready) {
-    std::cerr << "SyncNativeEntryPoint: no persisted config, skipping background wake" << std::endl;
+    platform::logError("SalveDb", "SyncNativeEntryPoint: no persisted config, skipping background wake");
     return;
   }
 
@@ -45,10 +45,10 @@ NativeBackgroundConstraints nativeBackgroundConstraints() {
   try {
     DatabaseManager::shared().reopenFromPersistedConfigIfNeeded();
   } catch (const std::exception& e) {
-    std::cerr << "SyncNativeEntryPoint: nativeBackgroundConstraints failed to rehydrate: " << e.what() << std::endl;
+    platform::logError("SalveDb", std::string("SyncNativeEntryPoint: nativeBackgroundConstraints failed to rehydrate: ") + e.what());
     return NativeBackgroundConstraints{false, 0, false, false};
   } catch (...) {
-    std::cerr << "SyncNativeEntryPoint: nativeBackgroundConstraints failed to rehydrate with an unknown exception" << std::endl;
+    platform::logError("SalveDb", "SyncNativeEntryPoint: nativeBackgroundConstraints failed to rehydrate with an unknown exception");
     return NativeBackgroundConstraints{false, 0, false, false};
   }
 

--- a/cpp/sync/SyncOrchestrator.cpp
+++ b/cpp/sync/SyncOrchestrator.cpp
@@ -9,7 +9,7 @@
 #include "../expression/RequestExpressionEvaluator.hpp"
 #include "../http/CredentialHttpCaller.hpp"
 #include "../http/SyncHttpCaller.hpp"
-#include <iostream>
+#include "../platform/platform.hpp"
 #include <stdexcept>
 #include <thread>
 #include <variant>
@@ -210,7 +210,7 @@ std::vector<NativeSyncResult> SyncOrchestrator::triggerSyncAll(bool discardIfBus
     : DatabaseManager::shared().lockSync();
 
   if (discardIfBusy && !lock.owns_lock()) {
-    std::cerr << "SyncOrchestrator: sync already in progress, discarding triggerSyncAll" << std::endl;
+    platform::logError("SalveDb", "SyncOrchestrator: sync already in progress, discarding triggerSyncAll");
     return {};
   }
 
@@ -221,7 +221,7 @@ std::vector<NativeSyncResult> SyncOrchestrator::triggerSyncAll(bool discardIfBus
     try {
       results.push_back(runSyncSession(schemaName));
     } catch (const std::exception& e) {
-      std::cerr << "SyncOrchestrator: triggerSyncAll — schema '" << schemaName << "' failed: " << e.what() << std::endl;
+      platform::logError("SalveDb", "SyncOrchestrator: triggerSyncAll — schema '" + schemaName + "' failed: " + e.what());
     }
   }
   return results;

--- a/cpp/tests/support/platform_test.cpp
+++ b/cpp/tests/support/platform_test.cpp
@@ -1,6 +1,7 @@
 #include "../../platform/platform.hpp"
 #include "platform_test.hpp"
 #include <cstdlib>
+#include <iostream>
 #include <stdexcept>
 #include <unistd.h>
 #include <unordered_map>
@@ -48,6 +49,10 @@ void deleteSecureValue(const std::string& key) {
 
 void scheduleBackgroundSync() noexcept {
   test::scheduleBackgroundSyncCallCount()++;
+}
+
+void logError(const std::string& tag, const std::string& message) noexcept {
+  std::cerr << "[" << tag << "] " << message << std::endl;
 }
 
 namespace test {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { SalveDbProvider } from '@salve-software/react-native-salve-db';
-// import Salvetron from '@salve-software/salvetron-react-native';
+import Salvetron from '@salve-software/salvetron-react-native';
 import { ExpenseSchema } from './src/schemas/ExpenseSchema';
 import { BudgetSchema } from './src/schemas/BudgetSchema';
 import { BenchmarkSchema } from './src/schemas/BenchmarkSchema';
@@ -16,9 +16,9 @@ import { BenchmarkScreen } from './src/screens/BenchmarkScreen';
 import { SyncTestScreen } from './src/screens/SyncTestScreen';
 import { MOCK_SYNC_SERVER_BASE_URL } from './src/library/mockSyncServer';
 
-// if (__DEV__) {
-//   Salvetron.connect({ host: 'localhost', port: 8765 });
-// }
+if (__DEV__) {
+  Salvetron.connect({ host: 'localhost', port: 8765 });
+}
 
 const ACCENT = '#5B5FEF';
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { SalveDbProvider } from '@salve-software/react-native-salve-db';
-import Salvetron from '@salve-software/salvetron-react-native';
+// import Salvetron from '@salve-software/salvetron-react-native';
 import { ExpenseSchema } from './src/schemas/ExpenseSchema';
 import { BudgetSchema } from './src/schemas/BudgetSchema';
 import { BenchmarkSchema } from './src/schemas/BenchmarkSchema';
@@ -16,9 +16,9 @@ import { BenchmarkScreen } from './src/screens/BenchmarkScreen';
 import { SyncTestScreen } from './src/screens/SyncTestScreen';
 import { MOCK_SYNC_SERVER_BASE_URL } from './src/library/mockSyncServer';
 
-if (__DEV__) {
-  Salvetron.connect({ host: 'localhost', port: 8765 });
-}
+// if (__DEV__) {
+//   Salvetron.connect({ host: 'localhost', port: 8765 });
+// }
 
 const ACCENT = '#5B5FEF';
 
@@ -71,6 +71,7 @@ function App(): React.JSX.Element {
               response: { accessToken: '$.accessToken', refreshToken: '$.refreshToken' },
             },
           },
+          background: { minimumInterval: 15 * 60 * 1000, requiresNetwork: false },
         }}
         schemas={[
           ExpenseSchema,

--- a/ios/SalveDbPlatform.mm
+++ b/ios/SalveDbPlatform.mm
@@ -81,4 +81,8 @@ void scheduleBackgroundSync() noexcept {
   [SalveDbBackgroundScheduler scheduleNext];
 }
 
+void logError(const std::string& tag, const std::string& message) noexcept {
+  NSLog(@"[%s] %s", tag.c_str(), message.c_str());
+}
+
 } // namespace margelo::nitro::salvedb::platform


### PR DESCRIPTION
## Summary
- Adds `platform::logError(tag, message)` — routes diagnostics through the platform's real log channel instead of `std::cerr`, which is silently dropped on Android in background execution and never reaches logcat.
- Android implementation uses `__android_log_print`, iOS uses `NSLog`, test harness uses `std::cerr`.
- Migrates all sync-path diagnostics (`SyncNativeEntryPoint`, `SyncOrchestrator`) to use it, so background sync failures (TASK-011 scheduler) are now observable on-device.
- Example app: adds `background: { minimumInterval, requiresNetwork }` to the sync config to exercise the new background scheduler path.

## Test plan
- [x] `npm run test:native` — 417 assertions / 158 test cases passing, log lines confirmed going through the new `logError` path in the test harness
- [ ] Manual on-device check that Android logcat and iOS console show `[SalveDb] ...` entries for background sync errors