### PR TITLE
feat: FK relations contract + cascade rewrite (issue #76)

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/sync/SyncCursorStore.cpp
 	../cpp/sync/SyncOperationApplier.cpp
 	../cpp/sync/RelationStore.cpp
+	../cpp/sync/RelationCascadeRewriter.cpp
 	../cpp/expression/RequestExpressionEvaluator.cpp
 	../cpp/expression/JsonPathExtractor.cpp
 	../cpp/credentials/CredentialProvider.cpp

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/sync/SyncDefinitionStore.cpp
 	../cpp/sync/SyncCursorStore.cpp
 	../cpp/sync/SyncOperationApplier.cpp
+	../cpp/sync/RelationStore.cpp
 	../cpp/expression/RequestExpressionEvaluator.cpp
 	../cpp/expression/JsonPathExtractor.cpp
 	../cpp/credentials/CredentialProvider.cpp

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -139,6 +139,20 @@ static constexpr auto kSyncMetadataRemoteIdIndex = R"sql(
     ON _salve_sync_metadata (tableName, remoteId);
 )sql";
 
+static constexpr auto kRelationsTable = R"sql(
+  CREATE TABLE IF NOT EXISTS _salve_relations (
+    childTable  TEXT NOT NULL,
+    fkColumn    TEXT NOT NULL,
+    parentTable TEXT NOT NULL,
+    PRIMARY KEY (childTable, fkColumn)
+  );
+)sql";
+
+static constexpr auto kRelationsParentIndex = R"sql(
+  CREATE INDEX IF NOT EXISTS idx_salve_relations_parent
+    ON _salve_relations (parentTable);
+)sql";
+
 int MigrationEngine::storedVersion(const std::string& schemaName) {
   auto result = _db->execute(
     "SELECT version FROM _salve_schema_versions WHERE name = ?",
@@ -343,6 +357,15 @@ void MigrationEngine::createSyncTriggers(const SchemaDef& schema) {
   _db->exec(deleteTrig.str());
 }
 
+void MigrationEngine::createRelationIndexes(const SchemaDef& schema) {
+  for (auto& rel : schema.relations) {
+    _db->exec(
+      "CREATE INDEX IF NOT EXISTS \"" + schema.name + "_" + rel.column + "_fk_idx\""
+      " ON \"" + schema.name + "\" (\"" + rel.column + "\")"
+    );
+  }
+}
+
 void MigrationEngine::dropSyncTriggers(const SchemaDef& schema) {
   const std::string& t = schema.name;
   _db->exec("DROP TRIGGER IF EXISTS \"" + t + "_sync_after_insert\";");
@@ -364,6 +387,8 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
   _db->exec(kSyncDefinitionTable);
   _db->exec(kSyncMetadataTable);
   _db->exec(kSyncMetadataRemoteIdIndex);
+  _db->exec(kRelationsTable);
+  _db->exec(kRelationsParentIndex);
 
   int stored = storedVersion(schema.name);
   bool columnsChanged = false;
@@ -405,6 +430,9 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
   } else {
     defStore.remove(schema.name);
   }
+
+  RelationStore(_db).replaceForChild(schema.name, schema.relations);
+  createRelationIndexes(schema);
 
   txn.commit();
 
@@ -463,6 +491,25 @@ SchemaDef MigrationEngine::parseSchemaJson(const std::string& jsonStr) {
       if (!idx.name.empty() && !idx.columns.empty()) {
         schema.indexes.push_back(std::move(idx));
       }
+    }
+  }
+
+  auto relationsVal = root.get("relations");
+  if (relationsVal && relationsVal->get().isArray()) {
+    for (auto& relVal : relationsVal->get().asArray()) {
+      if (!relVal.isObject()) continue;
+      RelationDef rel;
+      rel.column     = relVal.getString("column");
+      rel.references = relVal.getString("references");
+      if (rel.references.empty())
+        throw std::runtime_error("registerSchema: relation 'references' is required");
+      if (!schema.columns.count(rel.column))
+        throw std::runtime_error("registerSchema: relation column '" + rel.column + "' is not a declared column");
+      bool duplicate = std::any_of(schema.relations.begin(), schema.relations.end(),
+        [&](const RelationDef& r) { return r.column == rel.column; });
+      if (duplicate)
+        throw std::runtime_error("registerSchema: relation column '" + rel.column + "' is already declared");
+      schema.relations.push_back(std::move(rel));
     }
   }
 

--- a/cpp/database/MigrationEngine.hpp
+++ b/cpp/database/MigrationEngine.hpp
@@ -2,6 +2,7 @@
 
 #include "SQLiteConnection.hpp"
 #include "json_parser.hpp"
+#include "../sync/RelationStore.hpp"
 #include <memory>
 #include <string>
 #include <map>
@@ -36,6 +37,7 @@ struct SchemaDef {
   std::string primaryKey;
   std::map<std::string, ColumnDef> columns;
   std::vector<IndexDef> indexes;
+  std::vector<RelationDef> relations;
   SyncSettings sync;
 };
 
@@ -62,6 +64,8 @@ private:
 
   void createSyncTriggers(const SchemaDef& schema);
   void dropSyncTriggers(const SchemaDef& schema);
+
+  void createRelationIndexes(const SchemaDef& schema);
 };
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/sync/RelationCascadeRewriter.cpp
+++ b/cpp/sync/RelationCascadeRewriter.cpp
@@ -1,0 +1,19 @@
+#include "RelationCascadeRewriter.hpp"
+#include "RelationStore.hpp"
+
+namespace margelo::nitro::salvedb {
+
+RelationCascadeRewriter::RelationCascadeRewriter(std::shared_ptr<SQLiteConnection> conn)
+  : _conn(std::move(conn)) {}
+
+void RelationCascadeRewriter::rewrite(const std::string& parentTable, const std::string& oldId, const std::string& newId) {
+  auto relations = RelationStore(_conn).getRelationsReferencing(parentTable);
+  for (auto& rel : relations) {
+    _conn->execute(
+      "UPDATE \"" + rel.childTable + "\" SET \"" + rel.fkColumn + "\" = ? WHERE \"" + rel.fkColumn + "\" = ?",
+      { newId, oldId }
+    );
+  }
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/sync/RelationCascadeRewriter.hpp
+++ b/cpp/sync/RelationCascadeRewriter.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../database/SQLiteConnection.hpp"
+#include <memory>
+#include <string>
+
+namespace margelo::nitro::salvedb {
+
+// Rewrites child FK columns when a parent row's id changes from a temporary
+// to a server-assigned value. Multi-level cascade (grandparent -> parent ->
+// child) is an emergent property of multiple rewrite() calls across
+// successive sync events, not a recursive graph walk — an entity's id only
+// changes when that entity itself syncs. Must run inside the caller's
+// SyncApplyGuard::applyWithBypass; opens no transaction of its own.
+class RelationCascadeRewriter {
+public:
+  explicit RelationCascadeRewriter(std::shared_ptr<SQLiteConnection> conn);
+
+  void rewrite(const std::string& parentTable, const std::string& oldId, const std::string& newId);
+
+private:
+  std::shared_ptr<SQLiteConnection> _conn;
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/sync/RelationStore.cpp
+++ b/cpp/sync/RelationStore.cpp
@@ -1,0 +1,36 @@
+#include "RelationStore.hpp"
+
+namespace margelo::nitro::salvedb {
+
+RelationStore::RelationStore(std::shared_ptr<SQLiteConnection> conn)
+  : _conn(std::move(conn)) {}
+
+void RelationStore::replaceForChild(const std::string& childTable, const std::vector<RelationDef>& relations) {
+  _conn->execute("DELETE FROM _salve_relations WHERE childTable = ?", { childTable });
+  for (auto& rel : relations) {
+    _conn->execute(
+      "INSERT INTO _salve_relations (childTable, fkColumn, parentTable) VALUES (?, ?, ?)",
+      { childTable, rel.column, rel.references }
+    );
+  }
+}
+
+std::vector<RelationRow> RelationStore::getRelationsReferencing(const std::string& parentTable) {
+  auto result = _conn->execute(
+    "SELECT childTable, fkColumn, parentTable FROM _salve_relations WHERE parentTable = ?",
+    { parentTable }
+  );
+
+  std::vector<RelationRow> rows;
+  rows.reserve(result.rows.size());
+  for (auto& row : result.rows) {
+    rows.push_back(RelationRow{
+      std::get<std::string>(row[0]),
+      std::get<std::string>(row[1]),
+      std::get<std::string>(row[2])
+    });
+  }
+  return rows;
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/sync/RelationStore.hpp
+++ b/cpp/sync/RelationStore.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../database/SQLiteConnection.hpp"
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace margelo::nitro::salvedb {
+
+struct RelationDef {
+  std::string column;
+  std::string references;
+};
+
+struct RelationRow {
+  std::string childTable;
+  std::string fkColumn;
+  std::string parentTable;
+};
+
+// Plain C++ collaborator (not a HybridObject) — persists each schema's FK
+// relations in `_salve_relations`, so it survives a restart without depending
+// on JS having run register() in the current process.
+class RelationStore {
+public:
+  explicit RelationStore(std::shared_ptr<SQLiteConnection> conn);
+
+  void replaceForChild(const std::string& childTable, const std::vector<RelationDef>& relations);
+  std::vector<RelationRow> getRelationsReferencing(const std::string& parentTable);
+
+private:
+  std::shared_ptr<SQLiteConnection> _conn;
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/sync/SyncDefinitionStore.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncCursorStore.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncOperationApplier.cpp"
+  "${PROJECT_CPP_DIR}/sync/RelationStore.cpp"
   "${PROJECT_CPP_DIR}/expression/RequestExpressionEvaluator.cpp"
   "${PROJECT_CPP_DIR}/expression/JsonPathExtractor.cpp"
   "${PROJECT_CPP_DIR}/credentials/CredentialProvider.cpp"

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -123,6 +123,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/sync/SyncCursorStore.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncOperationApplier.cpp"
   "${PROJECT_CPP_DIR}/sync/RelationStore.cpp"
+  "${PROJECT_CPP_DIR}/sync/RelationCascadeRewriter.cpp"
   "${PROJECT_CPP_DIR}/expression/RequestExpressionEvaluator.cpp"
   "${PROJECT_CPP_DIR}/expression/JsonPathExtractor.cpp"
   "${PROJECT_CPP_DIR}/credentials/CredentialProvider.cpp"

--- a/cpp/tests/sync/RelationCascadeRewriterTests.cpp
+++ b/cpp/tests/sync/RelationCascadeRewriterTests.cpp
@@ -1,0 +1,235 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../platform/platform.hpp"
+#include "../../sync/RelationCascadeRewriter.hpp"
+#include "../../sync/RelationStore.hpp"
+#include "../../sync/SyncApplyGuard.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return platform::getDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+} // namespace
+
+TEST_CASE("rewrite updates only child rows whose FK matches oldId", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_single_child"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-1', 'temp-cust')", {});
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-2', 'other-cust')", {});
+
+  RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "cust-1");
+
+  auto ord1 = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(ord1.rows[0][0]) == "cust-1");
+  auto ord2 = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-2'", {});
+  REQUIRE(std::get<std::string>(ord2.rows[0][0]) == "other-cust");
+}
+
+TEST_CASE("cascade converges across a grandparent -> parent -> child chain via sequential syncs", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_multilevel"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "companies", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "companyId": { "type": "text" } },
+    "relations": [ { "column": "companyId", "references": "companies" } ]
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  conn->execute("INSERT INTO customers (id, companyId) VALUES ('temp-cust', 'temp-co')", {});
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-1', 'temp-cust')", {});
+
+  RelationCascadeRewriter rewriter(conn);
+  rewriter.rewrite("companies", "temp-co", "co-1");
+
+  auto customer = conn->execute("SELECT companyId FROM customers WHERE id = 'temp-cust'", {});
+  REQUIRE(std::get<std::string>(customer.rows[0][0]) == "co-1");
+
+  rewriter.rewrite("customers", "temp-cust", "cust-1");
+
+  auto order = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(order.rows[0][0]) == "cust-1");
+}
+
+TEST_CASE("rewrite only touches the FK matching the syncing parent, not a sibling FK", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_multi_fk"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "warehouses", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" }, "warehouseId": { "type": "text" } },
+    "relations": [
+      { "column": "customerId", "references": "customers" },
+      { "column": "warehouseId", "references": "warehouses" }
+    ]
+  })"));
+
+  conn->execute("INSERT INTO orders (id, customerId, warehouseId) VALUES ('ord-1', 'temp-cust', 'temp-wh')", {});
+
+  RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "cust-1");
+
+  auto row = conn->execute("SELECT customerId, warehouseId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "cust-1");
+  REQUIRE(std::get<std::string>(row.rows[0][1]) == "temp-wh");
+}
+
+TEST_CASE("rewrite updates every child table referencing the same parent", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_multi_child"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "invoices", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-1', 'temp-cust')", {});
+  conn->execute("INSERT INTO invoices (id, customerId) VALUES ('inv-1', 'temp-cust')", {});
+
+  RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "cust-1");
+
+  auto order = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(order.rows[0][0]) == "cust-1");
+  auto invoice = conn->execute("SELECT customerId FROM invoices WHERE id = 'inv-1'", {});
+  REQUIRE(std::get<std::string>(invoice.rows[0][0]) == "cust-1");
+}
+
+TEST_CASE("rewrite on a parent with no registered children touches no table", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_no_relations"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } }
+  })"));
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-1', 'temp-cust')", {});
+
+  RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "cust-1");
+
+  REQUIRE(RelationStore(conn).getRelationsReferencing("customers").empty());
+  auto row = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "temp-cust");
+}
+
+TEST_CASE("rewrite with an oldId matching no row changes nothing", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_no_match"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-1', 'other-cust')", {});
+
+  RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "cust-1");
+
+  auto row = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "other-cust");
+}
+
+TEST_CASE("rewrite converts the new id via the child column's integer affinity", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_integer_fk"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "integer" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  conn->execute("INSERT INTO orders (id, customerId) VALUES ('ord-1', 'temp-cust')", {});
+
+  RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "145");
+
+  auto row = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<double>(row.rows[0][0]) == 145.0);
+}
+
+TEST_CASE("rewrite performed inside applyWithBypass does not re-enqueue the rewritten child", "[sync][RelationCascadeRewriter]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("cascade_bypass"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" }, "updatedAt": { "type": "datetime", "nullable": false } },
+    "relations": [ { "column": "customerId", "references": "customers" } ],
+    "sync": { "enabled": true }
+  })"));
+
+  conn->execute("INSERT INTO orders (id, customerId, updatedAt) VALUES ('ord-1', 'temp-cust', 100)", {});
+  conn->execute("DELETE FROM sync_queue WHERE entity = 'orders'", {});
+  conn->execute("DELETE FROM _salve_sync_metadata WHERE tableName = 'orders'", {});
+
+  SyncApplyGuard(conn).applyWithBypass([&] {
+    RelationCascadeRewriter(conn).rewrite("customers", "temp-cust", "cust-1");
+  });
+
+  auto queued = conn->execute("SELECT COUNT(*) FROM sync_queue WHERE entity = 'orders'", {});
+  REQUIRE(std::get<double>(queued.rows[0][0]) == 0.0);
+  auto metadata = conn->execute("SELECT COUNT(*) FROM _salve_sync_metadata WHERE tableName = 'orders'", {});
+  REQUIRE(std::get<double>(metadata.rows[0][0]) == 0.0);
+
+  auto row = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "cust-1");
+}

--- a/cpp/tests/sync/RelationStoreTests.cpp
+++ b/cpp/tests/sync/RelationStoreTests.cpp
@@ -1,0 +1,220 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../platform/platform.hpp"
+#include "../../sync/RelationStore.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return platform::getDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+std::shared_ptr<SQLiteConnection> openWithRelationsTable(const std::string& testName) {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath(testName));
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } }
+  })"));
+  return conn;
+}
+
+} // namespace
+
+TEST_CASE("getRelationsReferencing returns empty when nothing registered", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_missing");
+  RelationStore store(conn);
+  REQUIRE(store.getRelationsReferencing("customers").empty());
+}
+
+TEST_CASE("replaceForChild persists and getRelationsReferencing reads it back", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_roundtrip");
+  RelationStore store(conn);
+
+  store.replaceForChild("orders", { RelationDef{"customerId", "customers"} });
+
+  auto rows = store.getRelationsReferencing("customers");
+  REQUIRE(rows.size() == 1);
+  REQUIRE(rows[0].childTable == "orders");
+  REQUIRE(rows[0].fkColumn == "customerId");
+  REQUIRE(rows[0].parentTable == "customers");
+}
+
+TEST_CASE("replaceForChild called twice with the same relations does not duplicate", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_idempotent");
+  RelationStore store(conn);
+
+  store.replaceForChild("orders", { RelationDef{"customerId", "customers"} });
+  store.replaceForChild("orders", { RelationDef{"customerId", "customers"} });
+
+  REQUIRE(store.getRelationsReferencing("customers").size() == 1);
+}
+
+TEST_CASE("replaceForChild drops a relation that disappeared in a newer version", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_stale");
+  RelationStore store(conn);
+
+  store.replaceForChild("orders", {
+    RelationDef{"customerId", "customers"},
+    RelationDef{"warehouseId", "warehouses"}
+  });
+  store.replaceForChild("orders", { RelationDef{"customerId", "customers"} });
+
+  REQUIRE(store.getRelationsReferencing("customers").size() == 1);
+  REQUIRE(store.getRelationsReferencing("warehouses").empty());
+}
+
+TEST_CASE("a child with two FKs to different parents is isolated per parent", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_multi_fk");
+  RelationStore store(conn);
+
+  store.replaceForChild("orders", {
+    RelationDef{"customerId", "customers"},
+    RelationDef{"warehouseId", "warehouses"}
+  });
+
+  REQUIRE(store.getRelationsReferencing("customers").size() == 1);
+  REQUIRE(store.getRelationsReferencing("warehouses").size() == 1);
+}
+
+TEST_CASE("two different children referencing the same parent are both returned", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_multi_child");
+  RelationStore store(conn);
+
+  store.replaceForChild("orders", { RelationDef{"customerId", "customers"} });
+  store.replaceForChild("invoices", { RelationDef{"customerId", "customers"} });
+
+  auto rows = store.getRelationsReferencing("customers");
+  REQUIRE(rows.size() == 2);
+}
+
+TEST_CASE("a saved relation survives constructing a new RelationStore over the same connection", "[sync][RelationStore]") {
+  auto conn = openWithRelationsTable("relations_persist_restart");
+  { RelationStore(conn).replaceForChild("orders", { RelationDef{"customerId", "customers"} }); }
+
+  RelationStore reopened(conn);
+  REQUIRE(reopened.getRelationsReferencing("customers").size() == 1);
+}
+
+TEST_CASE("MigrationEngine::registerSchema persists declared relations", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_registerschema"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  RelationStore store(conn);
+  auto rows = store.getRelationsReferencing("customers");
+  REQUIRE(rows.size() == 1);
+  REQUIRE(rows[0].childTable == "orders");
+}
+
+TEST_CASE("re-registering the same schema does not duplicate relations", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_registerschema_repeat"));
+  MigrationEngine engine(conn);
+
+  std::string schemaJson = R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })";
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+
+  RelationStore store(conn);
+  REQUIRE(store.getRelationsReferencing("customers").size() == 1);
+}
+
+TEST_CASE("registerSchema rejects a relation column that is not declared", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_invalid_column"));
+  MigrationEngine engine(conn);
+
+  CHECK_THROWS(engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })")));
+}
+
+TEST_CASE("registerSchema rejects a relation with an empty references", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_invalid_references"));
+  MigrationEngine engine(conn);
+
+  CHECK_THROWS(engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "" } ]
+  })")));
+}
+
+TEST_CASE("registerSchema rejects two relations declaring the same column", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_duplicate_column"));
+  MigrationEngine engine(conn);
+
+  CHECK_THROWS(engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [
+      { "column": "customerId", "references": "customers" },
+      { "column": "customerId", "references": "warehouses" }
+    ]
+  })")));
+}
+
+TEST_CASE("registerSchema creates an index on each declared FK column", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_fk_index"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  auto indexes = conn->execute(
+    "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'orders' AND name = 'orders_customerId_fk_idx'",
+    {}
+  );
+  REQUIRE(indexes.rows.size() == 1);
+}
+
+TEST_CASE("re-registering the same schema does not create duplicate indexes", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_fk_index_repeat"));
+  MigrationEngine engine(conn);
+
+  std::string schemaJson = R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })";
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+
+  auto indexes = conn->execute(
+    "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'orders' AND name = 'orders_customerId_fk_idx'",
+    {}
+  );
+  REQUIRE(indexes.rows.size() == 1);
+}
+
+TEST_CASE("relations are persisted even when the child schema has sync disabled", "[sync][RelationStore][integration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("relations_no_sync"));
+  MigrationEngine engine(conn);
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "customerId": { "type": "text" } },
+    "relations": [ { "column": "customerId", "references": "customers" } ]
+  })"));
+
+  RelationStore store(conn);
+  REQUIRE(store.getRelationsReferencing("customers").size() == 1);
+}

--- a/src/types/schemas/IRelationDefinition.ts
+++ b/src/types/schemas/IRelationDefinition.ts
@@ -1,0 +1,5 @@
+/** Foreign-key relation from this schema to a parent schema. */
+export interface IRelationDefinition<TEntity> {
+  column: keyof TEntity;
+  references: string;
+}

--- a/src/types/schemas/ISchemaDefinition.ts
+++ b/src/types/schemas/ISchemaDefinition.ts
@@ -1,6 +1,7 @@
 import type { ISyncDefinition } from "../sync";
 import type { IColumnDefinition } from "./IColumnDefinition";
 import type { IIndexDefinition } from "./IIndexDefinition";
+import type { IRelationDefinition } from "./IRelationDefinition";
 
 /** Declarative definition of a local schema (table). */
 export interface ISchemaDefinition<TEntity> {
@@ -22,6 +23,9 @@ export interface ISchemaDefinition<TEntity> {
 
   /** Indexes. */
   indexes?: IIndexDefinition[];
+
+  /** Foreign-key relations to parent schemas. */
+  relations?: IRelationDefinition<TEntity>[];
 
   /** Sync contract. */
   sync?: ISyncDefinition<TEntity>;

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -1,5 +1,6 @@
 export type * from './ISchemaDefinition';
 export type * from './IIndexDefinition';
+export type * from './IRelationDefinition';
 export type * from './IColumnDefinition';
 export type * from './ColumnTsType';
 export type * from './AnySchema';


### PR DESCRIPTION
## Summary

Implements Issue #76 (epic #74, sub-issue 2): declarative FK relations between schemas + the mechanism that rewrites a child's FK column when its parent syncs and its id changes from temporary to server-assigned.

- New `relations` field on `ISchemaDefinition` (`IRelationDefinition`: `{ column, references }`)
- New `_salve_relations` system table + `RelationStore`, persisted in SQL (mirrors `SyncDefinitionStore`'s pattern) so cascade lookups survive a background sync process that never ran JS `register()` this launch
- `MigrationEngine` parses/validates `relations` (declared column, non-empty `references`, no duplicate column) and auto-indexes each FK column to keep cascade rewrites off a full table scan
- New `RelationCascadeRewriter::rewrite(parentTable, oldId, newId)` — rewrites all direct children's FK columns; multi-level chains (grandparent → parent → child) resolve as an emergent effect of successive `rewrite()` calls across sync events, not a recursive graph walk

This sub-issue builds the mechanism in isolation, invoked directly in tests. Real invocation from the sync flow lands in #77 (blocked by this PR), which is why there's no end-to-end test through an actual sync session.

Closes #76

## Test plan

- [x] 181/181 native tests pass (453 assertions) — `RelationStoreTests.cpp`, `RelationCascadeRewriterTests.cpp`, no regressions in existing suites
- [x] Grandparent → parent → child cascade scenario from the acceptance criteria
- [x] `_sync_apply_lock` bypass verified — cascade rewrites don't re-enqueue themselves into `sync_queue`
- [x] Integer-affinity FK column covered (relations aren't restricted to `text` columns)
- [x] `tsc --noEmit` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring foreign-key relationships in schemas.
  * Added automatic indexing for declared relationships to improve lookup performance.
  * Updated related child records when parent identifiers change during synchronization.
  * Added publicly available TypeScript types for relationship definitions.

* **Bug Fixes**
  * Prevented duplicate or invalid relationship declarations.
  * Ensured relationship updates do not create unnecessary synchronization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->