### PR TITLE
Sub-issue 3: Replace Transaction (push-ack) no Sync Orchestrator

### DIFF
--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -121,6 +121,7 @@ static constexpr auto kSyncMetadataTable = R"sql(
   CREATE TABLE IF NOT EXISTS _salve_sync_metadata (
     tableName  TEXT NOT NULL,
     localId    TEXT NOT NULL,
+    entityId   TEXT NOT NULL,
     remoteId   TEXT,
     operation  TEXT NOT NULL,
     status     TEXT NOT NULL,
@@ -137,6 +138,13 @@ static constexpr auto kSyncMetadataTable = R"sql(
 static constexpr auto kSyncMetadataRemoteIdIndex = R"sql(
   CREATE INDEX IF NOT EXISTS idx_salve_sync_metadata_remote_id
     ON _salve_sync_metadata (tableName, remoteId);
+)sql";
+
+// ON CONFLICT target for the sync triggers below: a trigger only ever knows
+// NEW/OLD's current PK, so upserts must key off entityId, not the frozen localId.
+static constexpr auto kSyncMetadataEntityIdIndex = R"sql(
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_salve_sync_metadata_entity_id
+    ON _salve_sync_metadata (tableName, entityId);
 )sql";
 
 static constexpr auto kRelationsTable = R"sql(
@@ -299,11 +307,11 @@ void MigrationEngine::createSyncTriggers(const SchemaDef& schema) {
              << "    json_object(" << rowCols << "),\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER));\n"
              << "  INSERT INTO _salve_sync_metadata\n"
-             << "    (tableName, localId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)\n"
-             << "  VALUES ('" << t << "', NEW.\"" << pk << "\", NULL, 'insert', 'PENDING', 0, NULL,\n"
+             << "    (tableName, localId, entityId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)\n"
+             << "  VALUES ('" << t << "', NEW.\"" << pk << "\", NEW.\"" << pk << "\", NULL, 'insert', 'PENDING', 0, NULL,\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER),\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER), NULL)\n"
-             << "  ON CONFLICT(tableName, localId) DO UPDATE SET\n"
+             << "  ON CONFLICT(tableName, entityId) DO UPDATE SET\n"
              << "    operation = excluded.operation,\n"
              << "    status    = excluded.status,\n"
              << "    updatedAt = excluded.updatedAt;\n"
@@ -320,14 +328,14 @@ void MigrationEngine::createSyncTriggers(const SchemaDef& schema) {
              << "    json_object(" << rowCols << "),\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER));\n"
              << "  INSERT INTO _salve_sync_metadata\n"
-             << "    (tableName, localId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)\n"
-             << "  VALUES ('" << t << "', NEW.\"" << pk << "\", NULL,\n"
+             << "    (tableName, localId, entityId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)\n"
+             << "  VALUES ('" << t << "', NEW.\"" << pk << "\", NEW.\"" << pk << "\", NULL,\n"
              << "    CASE WHEN NEW.\"deletedAt\" IS NOT NULL THEN 'delete' ELSE 'update' END,\n"
              << "    CASE WHEN NEW.\"deletedAt\" IS NOT NULL THEN 'DELETED' ELSE 'PENDING' END,\n"
              << "    0, NULL,\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER),\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER), NULL)\n"
-             << "  ON CONFLICT(tableName, localId) DO UPDATE SET\n"
+             << "  ON CONFLICT(tableName, entityId) DO UPDATE SET\n"
              << "    operation = excluded.operation,\n"
              << "    status    = excluded.status,\n"
              << "    updatedAt = excluded.updatedAt;\n"
@@ -345,11 +353,11 @@ void MigrationEngine::createSyncTriggers(const SchemaDef& schema) {
              << "    json_object('" << pk << "', OLD.\"" << pk << "\"),\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER));\n"
              << "  INSERT INTO _salve_sync_metadata\n"
-             << "    (tableName, localId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)\n"
-             << "  VALUES ('" << t << "', OLD.\"" << pk << "\", NULL, 'delete', 'DELETED', 0, NULL,\n"
+             << "    (tableName, localId, entityId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)\n"
+             << "  VALUES ('" << t << "', OLD.\"" << pk << "\", OLD.\"" << pk << "\", NULL, 'delete', 'DELETED', 0, NULL,\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER),\n"
              << "    CAST(strftime('%s','now') * 1000 AS INTEGER), NULL)\n"
-             << "  ON CONFLICT(tableName, localId) DO UPDATE SET\n"
+             << "  ON CONFLICT(tableName, entityId) DO UPDATE SET\n"
              << "    operation = excluded.operation,\n"
              << "    status    = excluded.status,\n"
              << "    updatedAt = excluded.updatedAt;\n"
@@ -387,6 +395,16 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
   _db->exec(kSyncDefinitionTable);
   _db->exec(kSyncMetadataTable);
   _db->exec(kSyncMetadataRemoteIdIndex);
+
+  // Retro-migration for installs created before entityId existed (#77):
+  // split the frozen localId from the mutable "current PK" tracking column.
+  auto metadataColumns = existingColumns("_salve_sync_metadata");
+  if (std::find(metadataColumns.begin(), metadataColumns.end(), "entityId") == metadataColumns.end()) {
+    _db->exec("ALTER TABLE _salve_sync_metadata ADD COLUMN entityId TEXT NOT NULL DEFAULT ''");
+    _db->exec("UPDATE _salve_sync_metadata SET entityId = localId WHERE entityId = ''");
+  }
+  _db->exec(kSyncMetadataEntityIdIndex);
+
   _db->exec(kRelationsTable);
   _db->exec(kRelationsParentIndex);
 

--- a/cpp/database/SalveMetadataManager.cpp
+++ b/cpp/database/SalveMetadataManager.cpp
@@ -11,15 +11,16 @@ void SalveMetadataManager::upsert(const SyncMetadataRow& row) {
   using margelo::nitro::NullType;
   _conn->execute(
     "INSERT INTO _salve_sync_metadata"
-    " (tableName, localId, remoteId, operation, status, retryCount, lastError, version, createdAt, updatedAt, syncedAt)"
-    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    " (tableName, localId, entityId, remoteId, operation, status, retryCount, lastError, version, createdAt, updatedAt, syncedAt)"
+    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     " ON CONFLICT(tableName, localId) DO UPDATE SET"
-    " remoteId=excluded.remoteId, operation=excluded.operation, status=excluded.status,"
+    " entityId=excluded.entityId, remoteId=excluded.remoteId, operation=excluded.operation, status=excluded.status,"
     " retryCount=excluded.retryCount, lastError=excluded.lastError, version=excluded.version,"
     " updatedAt=excluded.updatedAt, syncedAt=excluded.syncedAt",
     {
       row.tableName,
       row.localId,
+      row.entityId,
       row.remoteId.has_value() ? SqlValue(row.remoteId.value()) : NullType{},
       row.operation,
       row.status,
@@ -33,46 +34,40 @@ void SalveMetadataManager::upsert(const SyncMetadataRow& row) {
   );
 }
 
-std::optional<SyncMetadataRow> SalveMetadataManager::getByLocalId(const std::string& tableName, const std::string& localId) {
-  auto result = _conn->execute(
-    "SELECT tableName, localId, remoteId, operation, status, retryCount, lastError, version, createdAt, updatedAt, syncedAt"
-    " FROM _salve_sync_metadata WHERE tableName = ? AND localId = ?",
-    { tableName, localId }
-  );
+namespace {
 
-  if (result.rows.empty()) return std::nullopt;
-
-  auto& row = result.rows[0];
+SyncMetadataRow rowToMetadata(const std::vector<SqlValue>& row) {
   SyncMetadataRow metadata;
   metadata.tableName = std::get<std::string>(row[0]);
   metadata.localId = std::get<std::string>(row[1]);
+  metadata.entityId = std::get<std::string>(row[2]);
 
-  const auto& remoteId = row[2];
+  const auto& remoteId = row[3];
   if (std::holds_alternative<std::string>(remoteId)) {
     const auto& val = std::get<std::string>(remoteId);
     if (!val.empty()) metadata.remoteId = val;
   }
 
-  metadata.operation = std::get<std::string>(row[3]);
-  metadata.status = std::get<std::string>(row[4]);
-  metadata.retryCount = static_cast<int>(std::get<double>(row[5]));
+  metadata.operation = std::get<std::string>(row[4]);
+  metadata.status = std::get<std::string>(row[5]);
+  metadata.retryCount = static_cast<int>(std::get<double>(row[6]));
 
-  const auto& lastError = row[6];
+  const auto& lastError = row[7];
   if (std::holds_alternative<std::string>(lastError)) {
     const auto& val = std::get<std::string>(lastError);
     if (!val.empty()) metadata.lastError = val;
   }
 
-  const auto& version = row[7];
+  const auto& version = row[8];
   if (std::holds_alternative<double>(version)) {
     double val = std::get<double>(version);
     if (val != 0.0) metadata.version = static_cast<int64_t>(val);
   }
 
-  metadata.createdAt = static_cast<int64_t>(std::get<double>(row[8]));
-  metadata.updatedAt = static_cast<int64_t>(std::get<double>(row[9]));
+  metadata.createdAt = static_cast<int64_t>(std::get<double>(row[9]));
+  metadata.updatedAt = static_cast<int64_t>(std::get<double>(row[10]));
 
-  const auto& syncedAt = row[10];
+  const auto& syncedAt = row[11];
   if (std::holds_alternative<double>(syncedAt)) {
     double val = std::get<double>(syncedAt);
     if (val != 0.0) metadata.syncedAt = static_cast<int64_t>(val);
@@ -81,52 +76,28 @@ std::optional<SyncMetadataRow> SalveMetadataManager::getByLocalId(const std::str
   return metadata;
 }
 
+} // namespace
+
+std::optional<SyncMetadataRow> SalveMetadataManager::getByLocalId(const std::string& tableName, const std::string& localId) {
+  auto result = _conn->execute(
+    "SELECT tableName, localId, entityId, remoteId, operation, status, retryCount, lastError, version, createdAt, updatedAt, syncedAt"
+    " FROM _salve_sync_metadata WHERE tableName = ? AND localId = ?",
+    { tableName, localId }
+  );
+
+  if (result.rows.empty()) return std::nullopt;
+  return rowToMetadata(result.rows[0]);
+}
+
 std::optional<SyncMetadataRow> SalveMetadataManager::getByRemoteId(const std::string& tableName, const std::string& remoteId) {
   auto result = _conn->execute(
-    "SELECT tableName, localId, remoteId, operation, status, retryCount, lastError, version, createdAt, updatedAt, syncedAt"
+    "SELECT tableName, localId, entityId, remoteId, operation, status, retryCount, lastError, version, createdAt, updatedAt, syncedAt"
     " FROM _salve_sync_metadata WHERE tableName = ? AND remoteId = ? LIMIT 1",
     { tableName, remoteId }
   );
 
   if (result.rows.empty()) return std::nullopt;
-
-  auto& row = result.rows[0];
-  SyncMetadataRow metadata;
-  metadata.tableName = std::get<std::string>(row[0]);
-  metadata.localId = std::get<std::string>(row[1]);
-
-  const auto& remoteIdVal = row[2];
-  if (std::holds_alternative<std::string>(remoteIdVal)) {
-    const auto& val = std::get<std::string>(remoteIdVal);
-    if (!val.empty()) metadata.remoteId = val;
-  }
-
-  metadata.operation = std::get<std::string>(row[3]);
-  metadata.status = std::get<std::string>(row[4]);
-  metadata.retryCount = static_cast<int>(std::get<double>(row[5]));
-
-  const auto& lastError = row[6];
-  if (std::holds_alternative<std::string>(lastError)) {
-    const auto& val = std::get<std::string>(lastError);
-    if (!val.empty()) metadata.lastError = val;
-  }
-
-  const auto& version = row[7];
-  if (std::holds_alternative<double>(version)) {
-    double val = std::get<double>(version);
-    if (val != 0.0) metadata.version = static_cast<int64_t>(val);
-  }
-
-  metadata.createdAt = static_cast<int64_t>(std::get<double>(row[8]));
-  metadata.updatedAt = static_cast<int64_t>(std::get<double>(row[9]));
-
-  const auto& syncedAt = row[10];
-  if (std::holds_alternative<double>(syncedAt)) {
-    double val = std::get<double>(syncedAt);
-    if (val != 0.0) metadata.syncedAt = static_cast<int64_t>(val);
-  }
-
-  return metadata;
+  return rowToMetadata(result.rows[0]);
 }
 
 void SalveMetadataManager::backfillSyncedRows(const std::string& tableName, const std::string& primaryKeyColumn) {
@@ -135,8 +106,8 @@ void SalveMetadataManager::backfillSyncedRows(const std::string& tableName, cons
 
   std::ostringstream sql;
   sql << "INSERT INTO _salve_sync_metadata"
-      << " (tableName, localId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)"
-      << " SELECT ?, \"" << primaryKeyColumn << "\", NULL, 'insert', 'PENDING', 0, NULL, ?, ?, NULL"
+      << " (tableName, localId, entityId, remoteId, operation, status, retryCount, version, createdAt, updatedAt, syncedAt)"
+      << " SELECT ?, \"" << primaryKeyColumn << "\", \"" << primaryKeyColumn << "\", NULL, 'insert', 'PENDING', 0, NULL, ?, ?, NULL"
       << " FROM \"" << tableName << "\""
       << " WHERE NOT EXISTS ("
       << "   SELECT 1 FROM _salve_sync_metadata"
@@ -144,6 +115,22 @@ void SalveMetadataManager::backfillSyncedRows(const std::string& tableName, cons
       << " )";
 
   _conn->execute(sql.str(), { tableName, static_cast<double>(nowMs), static_cast<double>(nowMs), tableName });
+}
+
+void SalveMetadataManager::markReplaced(const std::string& tableName, const std::string& localId,
+                                         const std::string& newEntityId, int64_t syncedAtMs) {
+  _conn->execute(
+    "UPDATE _salve_sync_metadata SET entityId = ?, remoteId = ?, status = 'SYNCED',"
+    " syncedAt = ?, updatedAt = ? WHERE tableName = ? AND localId = ?",
+    { newEntityId, newEntityId, static_cast<double>(syncedAtMs), static_cast<double>(syncedAtMs), tableName, localId }
+  );
+}
+
+void SalveMetadataManager::markDeletedSynced(const std::string& tableName, const std::string& localId, int64_t syncedAtMs) {
+  _conn->execute(
+    "UPDATE _salve_sync_metadata SET syncedAt = ?, updatedAt = ? WHERE tableName = ? AND localId = ?",
+    { static_cast<double>(syncedAtMs), static_cast<double>(syncedAtMs), tableName, localId }
+  );
 }
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/SalveMetadataManager.hpp
+++ b/cpp/database/SalveMetadataManager.hpp
@@ -11,6 +11,7 @@ namespace margelo::nitro::salvedb {
 struct SyncMetadataRow {
   std::string tableName;
   std::string localId;
+  std::string entityId;
   std::optional<std::string> remoteId;
   std::string operation;
   std::string status;
@@ -31,6 +32,13 @@ public:
   std::optional<SyncMetadataRow> getByLocalId(const std::string& tableName, const std::string& localId);
   std::optional<SyncMetadataRow> getByRemoteId(const std::string& tableName, const std::string& remoteId);
   void backfillSyncedRows(const std::string& tableName, const std::string& primaryKeyColumn);
+
+  // Replace-transaction ack: entityId becomes the server id, status SYNCED.
+  void markReplaced(const std::string& tableName, const std::string& localId,
+                     const std::string& newEntityId, int64_t syncedAtMs);
+
+  // Soft-delete ack: confirms the delete without touching status (stays DELETED).
+  void markDeletedSynced(const std::string& tableName, const std::string& localId, int64_t syncedAtMs);
 
 private:
   std::shared_ptr<SQLiteConnection> _conn;

--- a/cpp/sync/SyncOperationApplier.cpp
+++ b/cpp/sync/SyncOperationApplier.cpp
@@ -1,5 +1,8 @@
 #include "SyncOperationApplier.hpp"
+#include "RelationCascadeRewriter.hpp"
+#include "../database/SalveMetadataManager.hpp"
 #include <NitroModules/Null.hpp>
+#include <chrono>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -36,6 +39,19 @@ SqlValue toSqlValue(const json::Value& v) {
   if (v.isNumber()) return v.asNumber();
   if (v.isString()) return v.asString();
   throw std::runtime_error("SyncOperationApplier: unsupported payload value type for a column");
+}
+
+// A server-assigned id may arrive as a JSON number or string; metadata stores it as TEXT.
+// Reuses json::stringify's own number formatting so large integer ids don't
+// round-trip through the default 6-digit stream precision into "1.5e+15".
+std::string jsonScalarToString(const json::Value& v) {
+  if (v.isString()) return v.asString();
+  if (v.isNumber()) {
+    std::ostringstream out;
+    json::detail::stringifyNumber(v.asNumber(), out);
+    return out.str();
+  }
+  throw std::runtime_error("SyncOperationApplier: ack primary key value must be a string or number");
 }
 
 } // namespace
@@ -123,6 +139,82 @@ ApplyStats SyncOperationApplier::apply(const std::string& expectedEntity, const 
       _conn->execute(sql.str(), values);
       stats.updated++;
     }
+  }
+
+  return stats;
+}
+
+ApplyStats SyncOperationApplier::applyAck(const std::string& expectedEntity, const json::Array& acks) {
+  ApplyStats stats;
+  if (acks.empty()) return stats;
+
+  TableColumns cols = describeTable(*_conn, expectedEntity);
+  SalveMetadataManager metadata(_conn);
+  int64_t now = static_cast<int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count());
+
+  for (const auto& ack : acks) {
+    if (!ack.isObject()) {
+      throw std::runtime_error("SyncOperationApplier: each ack must be an object");
+    }
+
+    std::string localId = ack.getString("localId");
+    if (localId.empty()) {
+      throw std::runtime_error("SyncOperationApplier: ack is missing 'localId'");
+    }
+
+    auto meta = metadata.getByLocalId(expectedEntity, localId);
+    if (!meta) {
+      throw std::runtime_error(
+        "SyncOperationApplier: no metadata found for localId '" + localId + "' on entity '" + expectedEntity + "'"
+      );
+    }
+
+    if (meta->status == "DELETED") {
+      metadata.markDeletedSynced(expectedEntity, localId, now);
+      continue;
+    }
+
+    std::string oldEntityId = meta->entityId;
+    std::vector<std::string> columns;
+    std::vector<SqlValue> values;
+    std::optional<std::string> newEntityId;
+
+    for (auto& [key, val] : ack.asObject()) {
+      if (key == "localId") continue;
+      if (cols.all.count(key) == 0) {
+        throw std::runtime_error(
+          "SyncOperationApplier: unknown ack column '" + key + "' for entity '" + expectedEntity + "'"
+        );
+      }
+      columns.push_back(key);
+      if (key == cols.primaryKey) {
+        // Bind the same string form used for entityId/cascade/metadata below,
+        // rather than a raw double — SQLite's REAL->TEXT affinity conversion
+        // would otherwise reformat a large id into scientific notation.
+        newEntityId = jsonScalarToString(val);
+        values.push_back(*newEntityId);
+      } else {
+        values.push_back(toSqlValue(val));
+      }
+    }
+
+    if (!columns.empty()) {
+      std::ostringstream sql;
+      sql << "UPDATE \"" << expectedEntity << "\" SET ";
+      for (size_t i = 0; i < columns.size(); ++i) { if (i) sql << ", "; sql << "\"" << columns[i] << "\" = ?"; }
+      sql << " WHERE \"" << cols.primaryKey << "\" = ?";
+      values.push_back(oldEntityId);
+      _conn->execute(sql.str(), values);
+    }
+
+    std::string resolvedEntityId = newEntityId.value_or(oldEntityId);
+    if (resolvedEntityId != oldEntityId) {
+      RelationCascadeRewriter(_conn).rewrite(expectedEntity, oldEntityId, resolvedEntityId);
+    }
+
+    metadata.markReplaced(expectedEntity, localId, resolvedEntityId, now);
+    stats.updated++;
   }
 
   return stats;

--- a/cpp/sync/SyncOperationApplier.hpp
+++ b/cpp/sync/SyncOperationApplier.hpp
@@ -25,6 +25,11 @@ public:
   // to an unrelated (or internal) table.
   ApplyStats apply(const std::string& expectedEntity, const json::Array& operations);
 
+  // Applies Replace Transaction acks: locates each row by localId, rewrites
+  // its PK to the server id, cascades child FKs, and freezes metadata as
+  // SYNCED. Must run inside SyncApplyGuard::applyWithBypass.
+  ApplyStats applyAck(const std::string& expectedEntity, const json::Array& acks);
+
 private:
   std::shared_ptr<SQLiteConnection> _conn;
 };

--- a/cpp/sync/SyncOrchestrator.cpp
+++ b/cpp/sync/SyncOrchestrator.cpp
@@ -158,6 +158,12 @@ NativeSyncResult SyncOrchestrator::runSyncSession(const std::string& schemaName)
       if (extracted && extracted->isArray()) appliedOps = extracted->asArray();
     }
 
+    json::Array acks;
+    if (auto ackPath = extractPathString(responseDef->get(), "ack")) {
+      auto extracted = JsonPathExtractor::extract(response.body, *ackPath);
+      if (extracted && extracted->isArray()) acks = extracted->asArray();
+    }
+
     std::optional<json::Value> newCursor;
     if (auto cursorPath = extractPathString(responseDef->get(), "cursor")) {
       newCursor = JsonPathExtractor::extract(response.body, *cursorPath);
@@ -170,6 +176,13 @@ NativeSyncResult SyncOrchestrator::runSyncSession(const std::string& schemaName)
     }
 
     applyGuard.applyWithBypass([&] {
+      // Acks first: if a pulled operation and an ack ever target the same row
+      // in one response, resolving the ack's id rewrite first makes the pulled
+      // op see the row under its final id and merge via lastWriteWins, instead
+      // of racing to INSERT a row that the ack's UPDATE is about to claim.
+      ApplyStats ackStats = applier.applyAck(schemaName, acks);
+      totalStats.updated += ackStats.updated;
+
       ApplyStats pageStats = applier.apply(schemaName, appliedOps);
       totalStats.inserted += pageStats.inserted;
       totalStats.updated  += pageStats.updated;

--- a/cpp/sync/SyncQueueReader.cpp
+++ b/cpp/sync/SyncQueueReader.cpp
@@ -49,7 +49,7 @@ json::Array SyncQueueReader::readOperations(int limit) {
   auto result = _conn->execute(
     "SELECT sq.operation, sq.entity, sq.entity_id, sq.payload, sq.updated_at, sm.localId, sm.remoteId "
     "FROM sync_queue sq "
-    "LEFT JOIN _salve_sync_metadata sm ON (sq.entity = sm.tableName AND sq.entity_id = sm.localId) "
+    "LEFT JOIN _salve_sync_metadata sm ON (sq.entity = sm.tableName AND sq.entity_id = sm.entityId) "
     "ORDER BY sq.id ASC LIMIT ?",
     { static_cast<double>(limit) }
   );
@@ -71,7 +71,7 @@ SyncQueuePage SyncQueueReader::readPage(const std::string& entity, int limit) {
   auto result = _conn->execute(
     "SELECT sq.id, sq.operation, sq.entity, sq.entity_id, sq.payload, sq.updated_at, sm.localId, sm.remoteId "
     "FROM sync_queue sq "
-    "LEFT JOIN _salve_sync_metadata sm ON (sq.entity = sm.tableName AND sq.entity_id = sm.localId) "
+    "LEFT JOIN _salve_sync_metadata sm ON (sq.entity = sm.tableName AND sq.entity_id = sm.entityId) "
     "WHERE sq.entity = ? ORDER BY sq.id ASC LIMIT ?",
     { entity, static_cast<double>(limit) }
   );

--- a/cpp/tests/sync/SalveMetadataManagerTests.cpp
+++ b/cpp/tests/sync/SalveMetadataManagerTests.cpp
@@ -1,0 +1,105 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/MigrationEngine.hpp"
+#include "../../database/SQLiteConnection.hpp"
+#include "../../database/SalveMetadataManager.hpp"
+#include "../../platform/platform.hpp"
+#include <memory>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbPath(const std::string& testName) {
+  static int counter = 0;
+  return platform::getDocumentsDirectory() + "/" + testName + "_" + std::to_string(++counter) + ".db";
+}
+
+std::shared_ptr<SQLiteConnection> openWithCustomers(const std::string& testName) {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath(testName));
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "text" },
+      "name": { "type": "text" },
+      "updatedAt": { "type": "datetime", "nullable": false }
+    },
+    "sync": { "enabled": true }
+  })"));
+  return conn;
+}
+
+} // namespace
+
+TEST_CASE("getByLocalId returns the row's entityId", "[sync][SalveMetadataManager]") {
+  auto conn = openWithCustomers("metadata_get_by_local_id");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+
+  SalveMetadataManager metadata(conn);
+  auto row = metadata.getByLocalId("customers", "temp-1");
+
+  REQUIRE(row.has_value());
+  REQUIRE(row->entityId == "temp-1");
+  REQUIRE(row->status == "PENDING");
+}
+
+TEST_CASE("markReplaced updates entityId/remoteId/status/syncedAt and preserves localId", "[sync][SalveMetadataManager]") {
+  auto conn = openWithCustomers("metadata_mark_replaced");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+
+  SalveMetadataManager metadata(conn);
+  metadata.markReplaced("customers", "temp-1", "srv-1", 999);
+
+  auto row = metadata.getByLocalId("customers", "temp-1");
+  REQUIRE(row.has_value());
+  REQUIRE(row->localId == "temp-1");
+  REQUIRE(row->entityId == "srv-1");
+  REQUIRE(row->remoteId == "srv-1");
+  REQUIRE(row->status == "SYNCED");
+  REQUIRE(row->syncedAt == 999);
+}
+
+TEST_CASE("markDeletedSynced stamps syncedAt and keeps status DELETED", "[sync][SalveMetadataManager]") {
+  auto conn = openWithCustomers("metadata_mark_deleted_synced");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('1', 'alice', 100)", {});
+  conn->execute("DELETE FROM customers WHERE id = '1'", {});
+
+  SalveMetadataManager metadata(conn);
+  metadata.markDeletedSynced("customers", "1", 999);
+
+  auto row = metadata.getByLocalId("customers", "1");
+  REQUIRE(row.has_value());
+  REQUIRE(row->status == "DELETED");
+  REQUIRE(row->syncedAt == 999);
+}
+
+TEST_CASE("backfillSyncedRows writes entityId equal to the primary key", "[sync][SalveMetadataManager]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("metadata_backfill"));
+  MigrationEngine plainEngine(conn);
+  plainEngine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "text" },
+      "name": { "type": "text" },
+      "updatedAt": { "type": "datetime", "nullable": false }
+    }
+  })"));
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('pre-existing', 'alice', 100)", {});
+
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 2, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "text" },
+      "name": { "type": "text" },
+      "updatedAt": { "type": "datetime", "nullable": false }
+    },
+    "sync": { "enabled": true }
+  })"));
+
+  SalveMetadataManager metadata(conn);
+  auto row = metadata.getByLocalId("customers", "pre-existing");
+  REQUIRE(row.has_value());
+  REQUIRE(row->entityId == "pre-existing");
+  REQUIRE(row->status == "PENDING");
+}

--- a/cpp/tests/sync/SyncOperationApplierTests.cpp
+++ b/cpp/tests/sync/SyncOperationApplierTests.cpp
@@ -2,6 +2,7 @@
 #include "../../database/MigrationEngine.hpp"
 #include "../../database/SQLiteConnection.hpp"
 #include "../../platform/platform.hpp"
+#include "../../sync/SyncApplyGuard.hpp"
 #include "../../sync/SyncOperationApplier.hpp"
 #include <memory>
 
@@ -148,4 +149,154 @@ TEST_CASE("apply rejects a payload column that isn't a real column on the table"
   ])").asArray();
 
   REQUIRE_THROWS_AS(applier.apply("customers", ops), std::runtime_error);
+}
+
+TEST_CASE("applyAck preserves a large numeric server id without scientific-notation corruption", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_large_numeric_id");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+  SyncOperationApplier applier(conn);
+
+  auto acks = json::parse(R"([
+    { "localId": "temp-1", "id": 1500000000000000, "name": "alice", "updatedAt": 100 }
+  ])").asArray();
+
+  SyncApplyGuard(conn).applyWithBypass([&] { applier.applyAck("customers", acks); });
+
+  REQUIRE(nameOf(*conn, "1500000000000000") == "alice");
+
+  auto meta = conn->execute(
+    "SELECT entityId FROM _salve_sync_metadata WHERE tableName = 'customers' AND localId = 'temp-1'", {});
+  REQUIRE(std::get<std::string>(meta.rows[0][0]) == "1500000000000000");
+}
+
+TEST_CASE("applyAck replaces a temp id with the server id and marks metadata SYNCED", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_replace");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+  SyncOperationApplier applier(conn);
+
+  auto acks = json::parse(R"([
+    { "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 }
+  ])").asArray();
+
+  ApplyStats stats;
+  SyncApplyGuard(conn).applyWithBypass([&] {
+    stats = applier.applyAck("customers", acks);
+  });
+
+  REQUIRE(stats.updated == 1);
+  REQUIRE(nameOf(*conn, "srv-1") == "alice");
+  REQUIRE_FALSE(nameOf(*conn, "temp-1").has_value());
+
+  auto meta = conn->execute(
+    "SELECT entityId, remoteId, status FROM _salve_sync_metadata WHERE tableName = 'customers' AND localId = 'temp-1'", {});
+  REQUIRE(meta.rows.size() == 1);
+  REQUIRE(std::get<std::string>(meta.rows[0][0]) == "srv-1");
+  REQUIRE(std::get<std::string>(meta.rows[0][1]) == "srv-1");
+  REQUIRE(std::get<std::string>(meta.rows[0][2]) == "SYNCED");
+}
+
+TEST_CASE("applyAck does not duplicate the metadata row or touch sync_queue", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_no_duplication");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+  SyncOperationApplier applier(conn);
+
+  auto queueBefore = conn->execute("SELECT COUNT(*) FROM sync_queue WHERE entity = 'customers'", {});
+
+  auto acks = json::parse(R"([
+    { "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 }
+  ])").asArray();
+  SyncApplyGuard(conn).applyWithBypass([&] { applier.applyAck("customers", acks); });
+
+  auto metaCount = conn->execute("SELECT COUNT(*) FROM _salve_sync_metadata WHERE tableName = 'customers'", {});
+  REQUIRE(std::get<double>(metaCount.rows[0][0]) == 1.0);
+
+  auto queueAfter = conn->execute("SELECT COUNT(*) FROM sync_queue WHERE entity = 'customers'", {});
+  REQUIRE(std::get<double>(queueAfter.rows[0][0]) == std::get<double>(queueBefore.rows[0][0]));
+}
+
+TEST_CASE("applyAck cascades child FK rewrites via RelationCascadeRewriter", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_cascade");
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "orders", "version": 1, "primaryKey": "id",
+    "columns": {
+      "id": { "type": "text" },
+      "customerId": { "type": "text" },
+      "updatedAt": { "type": "datetime", "nullable": false }
+    },
+    "relations": [ { "column": "customerId", "references": "customers" } ],
+    "sync": { "enabled": true }
+  })"));
+
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+  conn->execute("INSERT INTO orders (id, customerId, updatedAt) VALUES ('ord-1', 'temp-1', 100)", {});
+
+  SyncOperationApplier applier(conn);
+  auto acks = json::parse(R"([{ "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 }])").asArray();
+  SyncApplyGuard(conn).applyWithBypass([&] { applier.applyAck("customers", acks); });
+
+  auto order = conn->execute("SELECT customerId FROM orders WHERE id = 'ord-1'", {});
+  REQUIRE(std::get<std::string>(order.rows[0][0]) == "srv-1");
+}
+
+TEST_CASE("applyAck marks a soft-deleted row's metadata synced without erroring", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_soft_delete");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('1', 'alice', 100)", {});
+  conn->execute("DELETE FROM customers WHERE id = '1'", {});
+  SyncOperationApplier applier(conn);
+
+  auto acks = json::parse(R"([{ "localId": "1" }])").asArray();
+
+  REQUIRE_NOTHROW(SyncApplyGuard(conn).applyWithBypass([&] {
+    applier.applyAck("customers", acks);
+  }));
+
+  auto meta = conn->execute(
+    "SELECT status, syncedAt FROM _salve_sync_metadata WHERE tableName = 'customers' AND localId = '1'", {});
+  REQUIRE(std::get<std::string>(meta.rows[0][0]) == "DELETED");
+  REQUIRE(std::get<double>(meta.rows[0][1]) != 0.0);
+}
+
+TEST_CASE("applyAck rejects an unknown ack column", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_unknown_column");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+  SyncOperationApplier applier(conn);
+
+  auto acks = json::parse(R"([{ "localId": "temp-1", "id": "srv-1", "notAColumn": "x", "updatedAt": 100 }])").asArray();
+
+  REQUIRE_THROWS_AS(
+    SyncApplyGuard(conn).applyWithBypass([&] { applier.applyAck("customers", acks); }),
+    std::runtime_error
+  );
+}
+
+TEST_CASE("applyAck rejects an ack whose localId has no matching metadata", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_orphan");
+  SyncOperationApplier applier(conn);
+
+  auto acks = json::parse(R"([{ "localId": "ghost", "id": "srv-1", "updatedAt": 100 }])").asArray();
+
+  REQUIRE_THROWS_AS(
+    SyncApplyGuard(conn).applyWithBypass([&] { applier.applyAck("customers", acks); }),
+    std::runtime_error
+  );
+}
+
+TEST_CASE("a real edit after replace updates the same frozen localId row instead of duplicating it", "[sync][SyncOperationApplier]") {
+  auto conn = openWithCustomers("applier_ack_post_replace_edit");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+  SyncOperationApplier applier(conn);
+
+  auto acks = json::parse(R"([{ "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 }])").asArray();
+  SyncApplyGuard(conn).applyWithBypass([&] { applier.applyAck("customers", acks); });
+
+  // Real edit, outside the bypass — fires the update trigger normally.
+  conn->execute("UPDATE customers SET name = 'alice-v2', updatedAt = 200 WHERE id = 'srv-1'", {});
+
+  auto count = conn->execute("SELECT COUNT(*) FROM _salve_sync_metadata WHERE tableName = 'customers'", {});
+  REQUIRE(std::get<double>(count.rows[0][0]) == 1.0);
+
+  auto meta = conn->execute("SELECT localId, status FROM _salve_sync_metadata WHERE tableName = 'customers'", {});
+  REQUIRE(std::get<std::string>(meta.rows[0][0]) == "temp-1");
+  REQUIRE(std::get<std::string>(meta.rows[0][1]) == "PENDING");
 }

--- a/cpp/tests/sync/SyncOrchestratorTests.cpp
+++ b/cpp/tests/sync/SyncOrchestratorTests.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<SQLiteConnection> openOrchestratorFixture(
         "operations": { "$ref": "operations" },
         "pageSize": { "$ref": "pageSize" }
       } },
-      "response": { "cursor": "$.cursor", "operations": "$.operations", "hasMore": "$.hasMore" }
+      "response": { "cursor": "$.cursor", "operations": "$.operations", "ack": "$.ack", "hasMore": "$.hasMore" }
     }
   })"));
 
@@ -345,4 +345,131 @@ TEST_CASE("triggerSyncAll discards silently when a sync session is already in pr
   auto results = SyncOrchestrator().triggerSyncAll(/*discardIfBusy*/ true);
 
   REQUIRE(results.empty());
+}
+
+TEST_CASE("triggerSync applies a Replace Transaction ack: id rewritten, metadata SYNCED, no duplication", "[sync][SyncOrchestrator]") {
+  auto conn = openOrchestratorFixture("orchestrator_ack_replace");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{200, {}, R"({
+      "cursor": "c1", "hasMore": false, "operations": [],
+      "ack": [
+        { "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 }
+      ]
+    })"};
+  });
+
+  SyncOrchestrator orchestrator;
+  auto result = orchestrator.triggerSync("customers");
+
+  REQUIRE(result.updated == 1.0);
+  REQUIRE(syncQueueCount(*conn, "customers") == 0);
+
+  auto row = conn->execute("SELECT name FROM customers WHERE id = 'srv-1'", {});
+  REQUIRE(row.rows.size() == 1);
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "alice");
+
+  auto meta = conn->execute(
+    "SELECT COUNT(*), entityId, status FROM _salve_sync_metadata WHERE tableName = 'customers'", {});
+  REQUIRE(std::get<double>(meta.rows[0][0]) == 1.0);
+  REQUIRE(std::get<std::string>(meta.rows[0][1]) == "srv-1");
+  REQUIRE(std::get<std::string>(meta.rows[0][2]) == "SYNCED");
+}
+
+TEST_CASE("triggerSync applies acks across multiple pages", "[sync][SyncOrchestrator]") {
+  auto conn = openOrchestratorFixture("orchestrator_ack_pagination", /*pageSize*/ 1, /*maxPagesPerSession*/ 20);
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'a', 100)", {});
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-2', 'b', 100)", {});
+
+  int calls = 0;
+  platform::test::setHttpExecuteResult([&](const HttpRequest&) -> HttpOutcome {
+    ++calls;
+    std::string localId = "temp-" + std::to_string(calls);
+    std::string serverId = "srv-" + std::to_string(calls);
+    bool more = calls < 2;
+    return HttpResponse{200, {}, R"({"cursor": "c)" + std::to_string(calls) + R"(", "hasMore": )" + (more ? "true" : "false") +
+      R"(, "operations": [], "ack": [{ "localId": ")" + localId + R"(", "id": ")" + serverId + R"(", "updatedAt": 100 }]})"};
+  });
+
+  SyncOrchestrator().triggerSync("customers");
+
+  REQUIRE(calls == 2);
+  REQUIRE(syncQueueCount(*conn, "customers") == 0);
+
+  auto srv1 = conn->execute("SELECT COUNT(*) FROM customers WHERE id = 'srv-1'", {});
+  REQUIRE(std::get<double>(srv1.rows[0][0]) == 1.0);
+  auto srv2 = conn->execute("SELECT COUNT(*) FROM customers WHERE id = 'srv-2'", {});
+  REQUIRE(std::get<double>(srv2.rows[0][0]) == 1.0);
+}
+
+TEST_CASE("triggerSync applies a soft-delete ack without erroring", "[sync][SyncOrchestrator]") {
+  auto conn = openOrchestratorFixture("orchestrator_ack_soft_delete");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('1', 'a', 100)", {});
+  conn->execute("DELETE FROM customers WHERE id = '1'", {});
+
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{200, {}, R"({
+      "cursor": "c1", "hasMore": false, "operations": [],
+      "ack": [ { "localId": "1" } ]
+    })"};
+  });
+
+  SyncOrchestrator orchestrator;
+  REQUIRE_NOTHROW(orchestrator.triggerSync("customers"));
+
+  auto meta = conn->execute(
+    "SELECT status, syncedAt FROM _salve_sync_metadata WHERE tableName = 'customers' AND localId = '1'", {});
+  REQUIRE(std::get<std::string>(meta.rows[0][0]) == "DELETED");
+  REQUIRE(std::get<double>(meta.rows[0][1]) != 0.0);
+}
+
+TEST_CASE("triggerSync applies an ack before a pulled operation targeting the same resulting row", "[sync][SyncOrchestrator]") {
+  auto conn = openOrchestratorFixture("orchestrator_ack_and_operation_same_row");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{200, {}, R"({
+      "cursor": "c1", "hasMore": false,
+      "ack": [
+        { "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 }
+      ],
+      "operations": [
+        { "operation": "update", "entity": "customers", "primaryKey": "srv-1",
+          "payload": { "id": "srv-1", "name": "alice-v2", "updatedAt": 200 }, "updatedAt": 200 }
+      ]
+    })"};
+  });
+
+  SyncOrchestrator orchestrator;
+  REQUIRE_NOTHROW(orchestrator.triggerSync("customers"));
+
+  // If the pulled operation ran before the ack, it would INSERT id='srv-1'
+  // ahead of the ack's UPDATE ... SET id='srv-1', colliding on the PK and
+  // rolling back the whole page. Processing the ack first avoids that.
+  auto rows = conn->execute("SELECT COUNT(*) FROM customers WHERE id = 'srv-1'", {});
+  REQUIRE(std::get<double>(rows.rows[0][0]) == 1.0);
+
+  auto row = conn->execute("SELECT name FROM customers WHERE id = 'srv-1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "alice-v2");
+}
+
+TEST_CASE("triggerSync's ack replace does not re-enqueue into sync_queue via the apply lock", "[sync][SyncOrchestrator]") {
+  auto conn = openOrchestratorFixture("orchestrator_ack_no_reentry");
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES ('temp-1', 'alice', 100)", {});
+
+  platform::test::setHttpExecuteResult([](const HttpRequest&) -> HttpOutcome {
+    return HttpResponse{200, {}, R"({
+      "cursor": "c1", "hasMore": false, "operations": [],
+      "ack": [ { "localId": "temp-1", "id": "srv-1", "name": "alice", "updatedAt": 100 } ]
+    })"};
+  });
+
+  SyncOrchestrator().triggerSync("customers");
+
+  REQUIRE(syncQueueCount(*conn, "customers") == 0);
+
+  auto pending = conn->execute(
+    "SELECT COUNT(*) FROM _salve_sync_metadata WHERE tableName = 'customers' AND status = 'PENDING'", {});
+  REQUIRE(std::get<double>(pending.rows[0][0]) == 0.0);
 }

--- a/cpp/tests/sync/SyncQueueReaderTests.cpp
+++ b/cpp/tests/sync/SyncQueueReaderTests.cpp
@@ -2,6 +2,7 @@
 #include "../../database/MigrationEngine.hpp"
 #include "../../database/SQLiteConnection.hpp"
 #include "../../platform/platform.hpp"
+#include "../../sync/SyncApplyGuard.hpp"
 #include "../../sync/SyncQueueReader.hpp"
 #include <memory>
 
@@ -144,4 +145,47 @@ TEST_CASE("readPage on an empty queue returns no maxId", "[sync][SyncQueueReader
 
   REQUIRE(page.operations.empty());
   REQUIRE_FALSE(page.maxId.has_value());
+}
+
+TEST_CASE("readOperations enriches each op with the frozen localId from metadata", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_local_id_enrichment"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES (1, 'a', 100)", {});
+
+  SyncQueueReader reader(conn);
+  auto ops = reader.readOperations(10);
+
+  REQUIRE(ops.size() == 1);
+  REQUIRE(ops[0].asObject().at("localId").asString() == "1");
+}
+
+TEST_CASE("readPage resolves the frozen localId via entityId after a replace", "[sync][SyncQueueReader]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("reader_post_replace"));
+  MigrationEngine engine(conn);
+  registerSyncEnabledCustomers(engine);
+
+  conn->execute("INSERT INTO customers (id, name, updatedAt) VALUES (1, 'a', 100)", {});
+  conn->execute("DELETE FROM sync_queue WHERE entity = 'customers'", {});
+
+  // Simulate a completed replace: PK rewritten to the server id inside the
+  // bypass (as applyAck does), entityId follows while localId stays frozen.
+  SyncApplyGuard(conn).applyWithBypass([&] {
+    conn->execute("UPDATE customers SET id = 2 WHERE id = 1", {});
+    conn->execute(
+      "UPDATE _salve_sync_metadata SET entityId = '2', remoteId = '2', status = 'SYNCED'"
+      " WHERE tableName = 'customers' AND localId = '1'", {});
+  });
+
+  // A later, real edit enqueues entity_id = 2 (the new PK).
+  conn->execute("UPDATE customers SET name = 'b', updatedAt = 200 WHERE id = 2", {});
+
+  SyncQueueReader reader(conn);
+  auto page = reader.readPage("customers", 10);
+
+  REQUIRE(page.operations.size() == 1);
+  const auto& op = page.operations[0].asObject();
+  REQUIRE(op.at("primaryKey").asString() == "2");
+  REQUIRE(op.at("localId").asString() == "1");
 }

--- a/src/types/sync/IResponseDefinition.ts
+++ b/src/types/sync/IResponseDefinition.ts
@@ -4,6 +4,8 @@ import type { JsonPath } from "../JsonPath";
 export interface IResponseDefinition<_TEntity> {
   cursor?: JsonPath;
   operations?: JsonPath;
+  /** Replace Transaction acks: `{ localId, <primaryKey>, ...replaced fields }[]`. */
+  ack?: JsonPath;
   entities?: JsonPath;
   deleted?: JsonPath;
   metadata?: JsonPath;


### PR DESCRIPTION
Closes #77

## Summary

Implements the "Replace Transaction" (push-ack) model for the Sync Orchestrator, including a retroactive fix to the identity model built in #75 that turned out to be required for this to work.

- **Identity foundation**: `_salve_sync_metadata` gains `entityId` (current, mutable PK) separate from `localId` (immutable, frozen at creation). Sync triggers now upsert on `ON CONFLICT(tableName, entityId)` — required because a trigger only ever sees the row's current PK, never the frozen `localId`. Includes an automatic retro-migration (`ALTER` + backfill) for installs that already ran #75.
- **`SyncOperationApplier::applyAck`**: for each ack, locates the row by `localId`, rewrites the local PK to the server id, invokes `RelationCascadeRewriter` to propagate child FK rewrites, and freezes the metadata as `SYNCED`. Soft-delete acks get `syncedAt` stamped without erroring.
- **`SyncOrchestrator`**: extracts `ack` from the response and applies it inside the existing `applyWithBypass` transaction, **before** the pulled `operations` — avoids a PK collision when the same row shows up in both lists on the same response.
- **`SyncQueueReader`**: join moved from `localId` to `entityId`, so edits made after a replace still resolve the correct metadata row.
- **`IResponseDefinition.ts`**: new `ack?: JsonPath` field.
- A large numeric server id is bound to the PK column using the same string form used for `entityId`/cascade/metadata, avoiding SQLite's REAL→TEXT affinity conversion reformatting it into scientific notation.

## Acceptance criteria (issue #77)

- [x] Full replace: create offline → sync → remoteId=145, status=SYNCED
- [x] No row duplication
- [x] Cascade rewrite (#76) is invoked and children are updated
- [x] No re-enqueue loop via `_sync_apply_lock`
- [x] Pagination respected
- [x] Soft-deleted records sync successfully

## Test plan

- [x] `npm run test:native` — full suite passing (512 assertions, 200 test cases)
- [x] `npx tsc --noEmit` — clean
- [x] Independent senior C++/mobile review (Opus) run over the diff; two findings (large numeric id precision and ack/operations ordering) fixed with dedicated regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)