### PR TITLE
fix(cpp): keep bare DELETE reactive on schemas without sync

### DIFF
--- a/.github/workflows/harness-ios.yml
+++ b/.github/workflows/harness-ios.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build iOS app
         working-directory: example/ios
         run: |
-          set -o pipefail && xcodebuild             CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++             -derivedDataPath build -UseModernBuildSystem=YES             -workspace SalveDbExample.xcworkspace             -scheme SalveDbExample             -sdk iphonesimulator             -configuration Debug             build             CODE_SIGNING_ALLOWED=NO
+          set -o pipefail && xcodebuild             CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++             -derivedDataPath build -UseModernBuildSystem=YES             -workspace SalveDbExample.xcworkspace             -scheme SalveDbExample             -sdk iphonesimulator             -configuration Debug             build             CODE_SIGN_IDENTITY=-             CODE_SIGNING_REQUIRED=NO
 
       - name: Start salve-db-server (PGlite test mode)
         working-directory: packages/salve-db-server

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -207,6 +207,14 @@ std::vector<std::string> MigrationEngine::existingColumns(const std::string& tab
   return cols;
 }
 
+bool MigrationEngine::tableExists(const std::string& tableName) {
+  auto result = _db->execute(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+    { tableName }
+  );
+  return !result.rows.empty();
+}
+
 // ── CREATE TABLE ──────────────────────────────────────────────────────────────
 
 void MigrationEngine::createTable(const SchemaDef& schema) {
@@ -446,7 +454,7 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
   int stored = storedVersion(schema.name);
   bool columnsChanged = false;
 
-  if (stored == 0) {
+  if (stored == 0 || !tableExists(schema.name)) {
     createTable(schema);
     columnsChanged = true;
   } else if (schema.version > stored) {

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -369,6 +369,21 @@ void MigrationEngine::createSyncTriggers(const SchemaDef& schema) {
   _db->exec(deleteTrig.str());
 }
 
+// A no-op AFTER DELETE trigger. Its only purpose is presence: SQLite's
+// "truncate optimization" (a bare `DELETE FROM t` with no WHERE drops the
+// btree instead of visiting rows) skips sqlite3_update_hook entirely, and it's
+// only disabled by the table having a DELETE trigger. Schemas without
+// sync.enabled otherwise get no triggers at all, so table-change
+// notifications for their bare deletes were silently lost (#63).
+void MigrationEngine::createChangeNotificationTrigger(const SchemaDef& schema) {
+  const std::string& t = schema.name;
+  _db->exec(
+    "CREATE TRIGGER IF NOT EXISTS \"" + t + "_change_notify_delete\"\n"
+    "AFTER DELETE ON \"" + t + "\"\n"
+    "BEGIN SELECT 1; END;"
+  );
+}
+
 void MigrationEngine::createRelationIndexes(const SchemaDef& schema) {
   for (auto& rel : schema.relations) {
     _db->exec(
@@ -440,6 +455,8 @@ void MigrationEngine::registerSchema(const SchemaDef& schema) {
     // Even at same version, ensure reserved columns exist (for library upgrades).
     columnsChanged = migrateTable(schema);
   }
+
+  createChangeNotificationTrigger(schema);
 
   if (schema.sync.enabled) {
     if (columnsChanged) {

--- a/cpp/database/MigrationEngine.hpp
+++ b/cpp/database/MigrationEngine.hpp
@@ -67,6 +67,7 @@ private:
 
   std::string sqliteType(const std::string& colType) const;
   std::vector<std::string> existingColumns(const std::string& tableName);
+  bool tableExists(const std::string& tableName);
 
   void createSyncTriggers(const SchemaDef& schema);
   void dropSyncTriggers(const SchemaDef& schema);

--- a/cpp/database/MigrationEngine.hpp
+++ b/cpp/database/MigrationEngine.hpp
@@ -70,6 +70,7 @@ private:
 
   void createSyncTriggers(const SchemaDef& schema);
   void dropSyncTriggers(const SchemaDef& schema);
+  void createChangeNotificationTrigger(const SchemaDef& schema);
 
   void createRelationIndexes(const SchemaDef& schema);
 };

--- a/cpp/tests/database/MigrationEngineTests.cpp
+++ b/cpp/tests/database/MigrationEngineTests.cpp
@@ -172,6 +172,36 @@ TEST_CASE("removing a column from the schema leaves it orphaned with data intact
   REQUIRE(storedVersion(*conn, "widgets") == 2);
 }
 
+TEST_CASE("registerSchema recreates a table dropped externally, even though _salve_schema_versions still has a stored version", "[migration]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("recreate_after_external_drop"));
+  MigrationEngine engine(conn);
+  std::string schemaJson = R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "label": { "type": "text" } }
+  })";
+
+  engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson));
+  conn->execute("INSERT INTO widgets (id, label) VALUES (1, 'a')", {});
+
+  // Simulates the Studio's "delete table" action: DROP TABLE without touching
+  // _salve_schema_versions.
+  conn->exec("DROP TABLE widgets");
+  REQUIRE(storedVersion(*conn, "widgets") == 1); // still stale
+
+  // Must not throw (previously fell through to ALTER TABLE on a table that
+  // no longer existed) and must fully recreate the table.
+  REQUIRE_NOTHROW(engine.registerSchema(MigrationEngine::parseSchemaJson(schemaJson)));
+
+  REQUIRE(columnsOf(*conn, "widgets") == std::vector<std::string>{"id", "label", "deletedAt"});
+  auto rows = conn->execute("SELECT COUNT(*) FROM widgets", {});
+  REQUIRE(std::get<double>(rows.rows[0][0]) == 0.0); // fresh table, old row is gone
+  REQUIRE(storedVersion(*conn, "widgets") == 1);
+
+  conn->execute("INSERT INTO widgets (id, label) VALUES (2, 'b')", {});
+  auto row = conn->execute("SELECT label FROM widgets WHERE id = 2", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "b");
+}
+
 TEST_CASE("opening at version N with a schema at N+2 applies all pending columns at once", "[migration]") {
   auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("multijump"));
   MigrationEngine engine(conn);

--- a/cpp/tests/database/MigrationEngineTests.cpp
+++ b/cpp/tests/database/MigrationEngineTests.cpp
@@ -3,6 +3,8 @@
 #include "../../database/SQLiteConnection.hpp"
 #include "../../platform/platform.hpp"
 #include <memory>
+#include <string>
+#include <vector>
 
 using namespace margelo::nitro::salvedb;
 
@@ -226,9 +228,21 @@ bool tableExists(SQLiteConnection& conn, const std::string& name) {
   return !r.rows.empty();
 }
 
+// Counts only the sync-queue triggers (name-prefixed "<table>_sync_..."),
+// excluding the always-on "<table>_change_notify_delete" trigger (#63) so
+// existing sync-trigger assertions don't need to know about it.
 int triggerCount(SQLiteConnection& conn, const std::string& tableName) {
-  auto r = conn.execute("SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?", { tableName });
+  auto r = conn.execute(
+    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ? AND name LIKE ?",
+    { tableName, tableName + "_sync_%" });
   return static_cast<int>(std::get<double>(r.rows[0][0]));
+}
+
+bool changeNotifyTriggerExists(SQLiteConnection& conn, const std::string& tableName) {
+  auto r = conn.execute(
+    "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+    { tableName + "_change_notify_delete" });
+  return !r.rows.empty();
 }
 
 std::string triggerSql(SQLiteConnection& conn, const std::string& name) {
@@ -282,7 +296,7 @@ TEST_CASE("sync.enabled: true creates 3 triggers matching schema.columns", "[mig
   REQUIRE(deleteSql.find("'name'") == std::string::npos); // delete payload is PK-only
 }
 
-TEST_CASE("sync.enabled: false or absent creates no triggers", "[migration][sync]") {
+TEST_CASE("sync.enabled: false or absent creates no sync triggers, but keeps the change-notification trigger", "[migration][sync]") {
   auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("sync_disabled"));
   MigrationEngine engine(conn);
 
@@ -291,6 +305,7 @@ TEST_CASE("sync.enabled: false or absent creates no triggers", "[migration][sync
     "columns": { "id": { "type": "integer" } }
   })"));
   REQUIRE(triggerCount(*conn, "no_sync_field") == 0);
+  REQUIRE(changeNotifyTriggerExists(*conn, "no_sync_field"));
 
   engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
     "name": "sync_off", "version": 1, "primaryKey": "id",
@@ -298,6 +313,7 @@ TEST_CASE("sync.enabled: false or absent creates no triggers", "[migration][sync
     "sync": { "enabled": false }
   })"));
   REQUIRE(triggerCount(*conn, "sync_off") == 0);
+  REQUIRE(changeNotifyTriggerExists(*conn, "sync_off"));
 }
 
 TEST_CASE("enabling sync.enabled with no column change still creates triggers", "[migration][sync]") {
@@ -389,4 +405,31 @@ TEST_CASE("sync.enabled: true without a datetime 'updatedAt' column throws", "[m
     "columns": { "id": { "type": "integer" }, "updatedAt": { "type": "datetime", "nullable": false } },
     "sync": { "enabled": true }
   })"));
+}
+
+TEST_CASE("a bare DELETE FROM with no WHERE on a schema without sync still notifies subscribers (#63)", "[migration][notify]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("bare_delete_no_sync"));
+  MigrationEngine engine(conn);
+
+  // No "sync" field at all — the case from the issue repro.
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "items", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "title": { "type": "text" } }
+  })"));
+
+  conn->execute("INSERT INTO items (id, title) VALUES (1, 'a')", {});
+  conn->execute("INSERT INTO items (id, title) VALUES (2, 'b')", {});
+
+  std::vector<std::vector<std::string>> received;
+  conn->subscribe([&](std::vector<std::string> tables) { received.push_back(tables); });
+
+  // Without the always-on change-notification trigger, SQLite's truncate
+  // optimization would skip sqlite3_update_hook entirely for this statement.
+  conn->execute("DELETE FROM items", {});
+
+  auto countRows = conn->execute("SELECT COUNT(*) FROM items", {});
+  REQUIRE(std::get<double>(countRows.rows[0][0]) == 0.0);
+
+  REQUIRE(received.size() == 1);
+  REQUIRE(received[0] == std::vector<std::string>{"items"});
 }

--- a/example/ios/SalveDbExample.xcodeproj/project.pbxproj
+++ b/example/ios/SalveDbExample.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SalveDbExample/SalveDbExample.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = SalveDbExample/Info.plist;
@@ -289,6 +290,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SalveDbExample/SalveDbExample.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = SalveDbExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;

--- a/example/ios/SalveDbExample/SalveDbExample.entitlements
+++ b/example/ios/SalveDbExample/SalveDbExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(CFBundleIdentifier)</string>
+	</array>
+</dict>
+</plist>

--- a/example/src/__harness__/SalveDb.hooks.harness.tsx
+++ b/example/src/__harness__/SalveDb.hooks.harness.tsx
@@ -129,6 +129,38 @@ describe('useQuery — real reactivity through the full native bridge', () => {
     await waitFor(() => expect(latest?.data).toEqual([row(2)]));
   });
 
+  it('a bare delete (no where()) on a schema without sync still notifies live queries (#63)', async () => {
+    const schema = {
+      name: uniqueName('hook_bare_delete_no_sync'),
+      version: 1,
+      primaryKey: 'id',
+      columns: { id: { type: 'integer' } },
+    } satisfies AnySchema;
+    const config = { name: uniqueName('e2e_bare_delete_no_sync') };
+
+    let latest: UseQueryResultOf<typeof schema> | undefined;
+
+    await render(
+      <SalveDbProvider config={config} schemas={[schema]}>
+        <QueryProbe schema={schema} onResult={(result) => { latest = result; }} />
+      </SalveDbProvider>
+    );
+
+    await waitFor(() => expect(latest?.data).toEqual([]));
+
+    Database.insert(schema).values({ id: 1 }).execute();
+    Database.insert(schema).values({ id: 2 }).execute();
+    await waitFor(() => expect(latest?.data).toEqual([row(1), row(2)]));
+
+    // No `.where()` — this is the exact repro from #63: on a schema with no
+    // `sync` block, SQLite's truncate optimization used to skip the update
+    // hook entirely for a WHERE-less DELETE, so this write never reached
+    // the live query below.
+    Database.delete(schema).execute();
+
+    await waitFor(() => expect(latest?.data).toEqual([]));
+  });
+
   it('two components querying the same schema+deps both react to one write', async () => {
     const schema = {
       name: uniqueName('hook_shared'),

--- a/example/src/__harness__/SalveDb.hooks.harness.tsx
+++ b/example/src/__harness__/SalveDb.hooks.harness.tsx
@@ -7,12 +7,6 @@ function uniqueName(prefix: string): string {
   return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
 }
 
-// deletedAt is a reserved column the engine adds to every table, so it comes
-// back on SELECT * alongside the schema's own columns.
-function row(id: number) {
-  return { id, deletedAt: null };
-}
-
 /** `useQuery`'s row type is inferred from the schema's literal `columns` shape — keep schema objects `satisfies AnySchema`, never `: AnySchema`, or that literal shape is lost. */
 type UseQueryResultOf<TSchema extends AnySchema> = ReturnType<typeof useQuery<TSchema>>;
 type UseInfiniteQueryResultOf<TSchema extends AnySchema> = ReturnType<typeof useInfiniteQuery<TSchema>>;

--- a/example/src/__harness__/SalveDb.readFlow.harness.tsx
+++ b/example/src/__harness__/SalveDb.readFlow.harness.tsx
@@ -28,6 +28,33 @@ function hasId(rows: unknown[] | null, id: number): boolean {
   return (rows ?? []).some((row) => (row as { id: number }).id === id);
 }
 
+// requestReadSync() is fire-and-forget (see src/sync/library/readSyncTrigger.ts):
+// mounting a probe returns before its triggered pull has actually finished
+// applying pages locally. Waiting for `latest` to merely go non-null races
+// that in-flight pull — a write made right after can still land inside it,
+// which would make a later "did the throttle block a second sync" check a
+// false negative. Poll until the row count holds steady to know the mount's
+// own pull has actually settled before moving on.
+async function waitForRowCountToSettle(getRows: () => unknown[] | null): Promise<void> {
+  const quietMs = 500;
+  const timeoutMs = 8000;
+  const pollMs = 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastCount = -1;
+  let stableSince = Date.now();
+
+  while (Date.now() < deadline) {
+    const count = (getRows() ?? []).length;
+    if (count !== lastCount) {
+      lastCount = count;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= quietMs) {
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+  }
+}
+
 // SyncOrchestrator requires a configured CredentialProvider to run any sync
 // session at all, even against a server that never checks auth — see
 // DatabaseManager::credentials() in cpp/database/DatabaseManager.hpp.
@@ -73,6 +100,10 @@ describe('Read-flow cache-first — useQuery triggers a background sync on read 
       </SalveDbProvider>
     );
     await waitFor(() => expect(latest).not.toBeNull(), 10000);
+    // The mount above only guarantees a read-triggered sync was *requested*,
+    // not that its fire-and-forget pull has applied all pages yet — settle
+    // first so the write below can't land inside that still-running sync.
+    await waitForRowCountToSettle(() => latest);
 
     // Write directly to the server right after the first read's sync already ran.
     const created = await createOnServer('Mara', `${uniqueName('mara')}@x.dev`);


### PR DESCRIPTION
## Summary
- Schemas without `sync.enabled` got no SQLite triggers, so a WHERE-less `Database.delete(schema).execute()` hit SQLite's truncate optimization and silently skipped `sqlite3_update_hook` — `useQuery`/`useInfiniteQuery` never learned the table changed.
- Always register a lightweight no-op `AFTER DELETE` trigger per table (independent of `sync.enabled`) in `MigrationEngine::registerSchema`. Its mere presence disables the truncate optimization, so the update hook fires normally again.
- Follow-up fix found while manually testing this in the Studio: `registerSchema` decided create-vs-migrate purely from the version stored in `_salve_schema_versions`, never checking the table itself still exists. An external `DROP TABLE` (e.g. Studio's "delete table" action) leaves that version row untouched, so the app crashed on every subsequent launch — `registerSchema` kept falling into the `ALTER TABLE` path against a table that no longer existed. Now it also checks `tableExists()` before deciding, so a missing table always goes through `createTable` again.
- Also fixes an unrelated pre-existing bug found while testing: `SalveDb.hooks.harness.tsx` had two identically-named `row()` declarations, which threw a strict-mode `SyntaxError` under Metro/Hermes and broke bundling for every test in that file.

Closes #63

## Test plan
- [x] `npm run test:native` — 683 assertions / 262 cases pass, including regression tests for both fixes (bare `DELETE` notification without sync, and recreate-after-external-`DROP TABLE`)
- [x] Updated existing `MigrationEngineTests.cpp` trigger-count assertions to account for the new always-on trigger
- [x] New `useQuery` test in `SalveDb.hooks.harness.tsx` run against a real iOS simulator through the full native bridge (no mocks): inserts rows on a schema without sync, runs a bare delete, asserts the live query drops to empty — 9/9 tests passed in that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bare deletes now reliably notify live queries, including for schemas without synchronization enabled.
  * Schemas are recreated correctly if their tables were removed externally, even when migration metadata remains.
  * Synchronization-disabled schemas no longer create unnecessary sync triggers.

* **Chores**
  * Improved iOS example project signing configuration for more reliable builds and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->