### PR TITLE
ci(release): re-enable main in the release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,7 @@ name: Release
 on:
   push:
     branches:
-      # 'main' is deliberately left out until v0.1.0 / salve-db-studio@0.0.1 are tagged on
-      # main post-merge — without those tags, the first automated run has no baseline and
-      # would treat this as a first release (semantic-release defaults that to 1.0.0),
-      # clobbering the versions already published manually. Add 'main' back once tagged.
+      - main
       - next
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Follow-up to #97. \`v0.1.0\` and \`salve-db-studio@0.0.1\` are now tagged on \`main\` (pushed after the merge, matching the versions already published manually to npm), so the automated pipeline has a real baseline to diff against. Re-adds \`main\` to \`release.yml\`'s push trigger, which was deliberately left out to avoid a premature first-release run before those tags existed.

## Test plan

- [x] Tags \`v0.1.0\` and \`salve-db-studio@0.0.1\` exist on \`main\` (pushed at the correct post-merge commit)
- [x] YAML validated with \`js-yaml\`
- [ ] Next merge to \`main\` runs the release pipeline against the tagged baseline (no premature 1.0.0 jump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release automation now runs for pushes to the `main` branch.
  * Removed outdated guidance indicating that `main` was excluded from release processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->