### PR TITLE
fix(build): clean lib/ before every build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit",
     "clean": "git clean -dfX",
     "release": "semantic-release",
-    "build": "npm run typecheck && bob build",
+    "build": "rm -rf lib && npm run typecheck && bob build",
     "codegen": "nitrogen --logLevel=\"debug\" && npm run build",
     "postcodegen": "npm --prefix example run pod",
     "db:studio": "npm run dev:server -w packages/salve-db-studio"


### PR DESCRIPTION
## Problem

The npm 0.1.0 tarball shipped a full legacy copy of the library — orphaned
`lib/index.js`, `lib/index.d.ts`, `lib/contracts/**` (old `SchemaDefinition`/
`SyncDefinition` types, pre-refactor batch/$ref sync protocol) — alongside
the current build output in `lib/commonjs`, `lib/module`, `lib/typescript`.

Root cause: `lib/` is gitignored and `bob build` never wiped it before
writing, so anything left over from an earlier architecture (before the
`commonjs`/`module`/`typescript` split, before the REST-based `ISyncDefinition`
refactor) just accumulated locally, untracked and unnoticed. A manual
`npm publish` packed whatever was sitting in that never-cleaned `lib/`,
so both generations shipped together.

The package's actual resolved entry point (`main`/`types` → `index.d.ts` →
`./types` → `./sync`) already exports the correct, current REST contract —
this dead code isn't reachable from anywhere the package publicly exports.
But editor auto-import (VS Code/TS scans *all* `.d.ts` under `node_modules`,
not just what's re-exported) can and did surface the dead types instead.

## Fix

`build` now runs `rm -rf lib` first, so every build starts from a guaranteed
clean state — manual or CI. Verified locally: rebuilt from scratch, `lib/`
now only contains `commonjs/module/typescript` (no `contracts/`, no stray
`index.js`), full test suite still green, `npm pack --dry-run` no longer
lists any `lib/contracts` or `lib/index.*` file.

Once this merges, it'll be a `fix:` commit landing on `main` — the first
real run of the automated release pipeline from #100, producing a clean
`0.1.1` from an ephemeral CI checkout (can't reintroduce this class of bug).

## Test plan

- [x] `npm run build` from a dirty `lib/` → old files gone after rebuild
- [x] `npm test` — 20 suites / 161 tests passing
- [x] `npm pack --dry-run` — no `lib/contracts` or `lib/index.*` entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to remove previous build output before generating new files, helping ensure clean and consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->