### PR TITLE
ci(release): drop test:native step from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,6 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Test native (C++/Hermes)
-        run: npm run test:native
-
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Problem

`release-core` runs `npm run test:native` on `ubuntu-latest`, but
`cpp/tests` links against the vendored macOS `hermesvm.framework`
(fetched by `pod install`) and hard-fails to even configure on Linux:

```
CMake Error at CMakeLists.txt:16 (message):
  salvedb_tests currently only supports macOS host builds (needs the
  vendored macOS hermesvm.framework).
```

This has failed on every push to `main` since the step was added —
runs for #100 and #101 both died here before `npm run build`/publish
ever executed.

## Fix

Drop the step from the release job. `cpp/**` changes are already
exercised on the PR gate to `main` via `harness-ios.yml` /
`harness-android.yml` (full example app, real device/simulator,
triggered on `pull_request` for `cpp/**`) before they can merge — not
the identical Catch2 suite, but the same native code paths.

## Test plan

- [ ] Next push to `main` runs `release-core` end to end without the
      CMake failure