### PR TITLE
fix(query): default select limit to MAX_SYNC_PAGE_SIZE

### DIFF
--- a/src/database/classes/QueryDb/classes/SelectQueryBuilder/SelectQueryBuilder.class.ts
+++ b/src/database/classes/QueryDb/classes/SelectQueryBuilder/SelectQueryBuilder.class.ts
@@ -44,11 +44,9 @@ export class SelectQueryBuilder<TSchema extends AnySchema>
   }
 
   execute(): InferSelectModel<TSchema>[] {
-    if (this._limit === undefined) {
-      throw new Error('execute() requires .limit() to be set (max MAX_SYNC_PAGE_SIZE) before calling.');
-    }
-    if (this._limit > MAX_SYNC_PAGE_SIZE) {
-      throw new Error(`execute() limit (${this._limit}) exceeds MAX_SYNC_PAGE_SIZE (${MAX_SYNC_PAGE_SIZE}).`);
+    const limit = this._limit === undefined ? MAX_SYNC_PAGE_SIZE : this._limit;
+    if (limit > MAX_SYNC_PAGE_SIZE) {
+      throw new Error(`execute() limit (${limit}) exceeds MAX_SYNC_PAGE_SIZE (${MAX_SYNC_PAGE_SIZE}).`);
     }
 
     const columnsNeedingIndex: string[] = [];
@@ -66,7 +64,7 @@ export class SelectQueryBuilder<TSchema extends AnySchema>
       sql += ` ORDER BY "${this._orderByColumn}" ${this._orderByDir.toUpperCase()}`;
     }
 
-    sql += ` LIMIT ${this._limit}`;
+    sql += ` LIMIT ${limit}`;
 
     if (this._offset !== undefined) {
       sql += ` OFFSET ${this._offset}`;

--- a/src/database/classes/QueryDb/classes/SelectQueryBuilder/SelectQueryBuilder.class.ts
+++ b/src/database/classes/QueryDb/classes/SelectQueryBuilder/SelectQueryBuilder.class.ts
@@ -45,6 +45,9 @@ export class SelectQueryBuilder<TSchema extends AnySchema>
 
   execute(): InferSelectModel<TSchema>[] {
     const limit = this._limit === undefined ? MAX_SYNC_PAGE_SIZE : this._limit;
+    if (!Number.isInteger(limit) || limit < 0) {
+      throw new Error(`execute() limit (${limit}) must be a non-negative integer.`);
+    }
     if (limit > MAX_SYNC_PAGE_SIZE) {
       throw new Error(`execute() limit (${limit}) exceeds MAX_SYNC_PAGE_SIZE (${MAX_SYNC_PAGE_SIZE}).`);
     }

--- a/src/database/classes/QueryDb/classes/SelectQueryBuilder/__tests__/SelectQueryBuilder.test.ts
+++ b/src/database/classes/QueryDb/classes/SelectQueryBuilder/__tests__/SelectQueryBuilder.test.ts
@@ -93,9 +93,11 @@ describe('SelectQueryBuilder — SQL generation', () => {
 });
 
 describe('SelectQueryBuilder — sync execution guardrails', () => {
-  test('throws when limit() was never called', () => {
+  test('defaults to MAX_SYNC_PAGE_SIZE when limit() was never called', () => {
     const bridge = makeBridge();
-    expect(() => new SelectQueryBuilder(schema, bridge).execute()).toThrow(/limit/i);
+    new SelectQueryBuilder(schema, bridge).execute();
+    const [sql] = executedWith(bridge);
+    expect(sql).toBe(`SELECT * FROM "users" WHERE "deletedAt" IS NULL LIMIT ${MAX_SYNC_PAGE_SIZE}`);
   });
 
   test('throws when limit() exceeds MAX_SYNC_PAGE_SIZE', () => {

--- a/src/database/classes/QueryDb/classes/SelectQueryBuilder/__tests__/SelectQueryBuilder.test.ts
+++ b/src/database/classes/QueryDb/classes/SelectQueryBuilder/__tests__/SelectQueryBuilder.test.ts
@@ -114,6 +114,27 @@ describe('SelectQueryBuilder — sync execution guardrails', () => {
     ).not.toThrow();
   });
 
+  test('throws when limit() is negative', () => {
+    const bridge = makeBridge();
+    expect(() =>
+      new SelectQueryBuilder(schema, bridge).limit(-1).execute()
+    ).toThrow(/non-negative integer/);
+  });
+
+  test('throws when limit() is fractional', () => {
+    const bridge = makeBridge();
+    expect(() =>
+      new SelectQueryBuilder(schema, bridge).limit(1.5).execute()
+    ).toThrow(/non-negative integer/);
+  });
+
+  test('throws when limit() is NaN', () => {
+    const bridge = makeBridge();
+    expect(() =>
+      new SelectQueryBuilder(schema, bridge).limit(NaN).execute()
+    ).toThrow(/non-negative integer/);
+  });
+
   test('throws when orderBy() targets a non-indexed, non-primary-key column', () => {
     const bridge = makeBridge();
     expect(() =>


### PR DESCRIPTION
## Summary
- `SelectQueryBuilder.execute()` no longer throws when `.limit()` was never called — it now defaults to `MAX_SYNC_PAGE_SIZE` (500).
- Explicit `.limit()` values above `MAX_SYNC_PAGE_SIZE` still throw (unchanged behavior).

## Test plan
- [x] `npx jest src/database/classes/QueryDb/classes/SelectQueryBuilder` — 16/16 passing
- [x] `npm run typecheck` — clean

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select queries now execute without requiring an explicit limit.
  * When no limit is provided, results are capped at the maximum supported page size.
  * Explicit limits continue to be validated and applied to generated queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->