### PR TITLE
feat(credentials): add auth header scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ export default function App() {
         baseUrl: 'https://api.myapp.com',
         credentials: {
           provider: 'oauth2',
+          // accessToken.headerName/scheme default to "Authorization"/"Bearer" — override for custom APIs.
           tokens: { accessToken, refreshToken },
           refresh: {
             endpoint: '/auth/refresh',

--- a/cpp/HybridSalveDatabase.cpp
+++ b/cpp/HybridSalveDatabase.cpp
@@ -44,6 +44,7 @@ void HybridSalveDatabase::configure(const ConfigureParams& params) {
       DatabaseManager::shared().configureCredentials(
         creds.provider,
         creds.accessTokenHeaderName,
+        creds.accessTokenScheme,
         creds.refresh.endpoint,
         creds.refresh.responseAccessTokenPath,
         creds.refresh.responseRefreshTokenPath,
@@ -66,6 +67,7 @@ void HybridSalveDatabase::configure(const ConfigureParams& params) {
     persisted.credentials = PersistedCredentialConfig{
       creds.provider,
       creds.accessTokenHeaderName,
+      creds.accessTokenScheme,
       creds.refresh.endpoint,
       creds.refresh.responseAccessTokenPath,
       creds.refresh.responseRefreshTokenPath

--- a/cpp/credentials/CredentialProvider.cpp
+++ b/cpp/credentials/CredentialProvider.cpp
@@ -17,12 +17,14 @@ const std::string kRefreshTokenKey = "salvedb.credentials.refreshToken";
 CredentialProvider::CredentialProvider(
   std::string provider,
   std::string accessTokenHeaderName,
+  std::string accessTokenScheme,
   std::string refreshEndpoint,
   std::string responseAccessTokenPath,
   std::string responseRefreshTokenPath
 )
   : _provider(std::move(provider)),
     _accessTokenHeaderName(std::move(accessTokenHeaderName)),
+    _accessTokenScheme(std::move(accessTokenScheme)),
     _refreshEndpoint(std::move(refreshEndpoint)),
     _responseAccessTokenPath(std::move(responseAccessTokenPath)),
     _responseRefreshTokenPath(std::move(responseRefreshTokenPath)) {}
@@ -45,7 +47,8 @@ std::pair<std::string, std::string> CredentialProvider::getAuthHeader() const {
   if (!token.has_value()) {
     throw std::runtime_error("CredentialProvider: no access token stored yet — call configure() with initial tokens first");
   }
-  return {_accessTokenHeaderName, *token};
+  std::string headerValue = _accessTokenScheme.empty() ? *token : _accessTokenScheme + " " + *token;
+  return {_accessTokenHeaderName, headerValue};
 }
 
 void CredentialProvider::refresh(const HttpCaller& httpCaller) {

--- a/cpp/credentials/CredentialProvider.hpp
+++ b/cpp/credentials/CredentialProvider.hpp
@@ -27,6 +27,7 @@ public:
   CredentialProvider(
     std::string provider,
     std::string accessTokenHeaderName,
+    std::string accessTokenScheme,
     std::string refreshEndpoint,
     std::string responseAccessTokenPath,
     std::string responseRefreshTokenPath
@@ -55,6 +56,7 @@ public:
 private:
   std::string _provider;
   std::string _accessTokenHeaderName;
+  std::string _accessTokenScheme;
   std::string _refreshEndpoint;
   std::string _responseAccessTokenPath;
   std::string _responseRefreshTokenPath;

--- a/cpp/database/DatabaseManager.cpp
+++ b/cpp/database/DatabaseManager.cpp
@@ -16,13 +16,14 @@ void DatabaseManager::open(const std::string& dbName, bool walMode) {
 void DatabaseManager::configureCredentials(
   const std::string& provider,
   const std::string& accessTokenHeaderName,
+  const std::string& accessTokenScheme,
   const std::string& refreshEndpoint,
   const std::string& responseAccessTokenPath,
   const std::string& responseRefreshTokenPath,
   const std::optional<InitialCredentialTokens>& initialTokens
 ) {
   _credentials = std::make_unique<CredentialProvider>(
-    provider, accessTokenHeaderName, refreshEndpoint, responseAccessTokenPath, responseRefreshTokenPath
+    provider, accessTokenHeaderName, accessTokenScheme, refreshEndpoint, responseAccessTokenPath, responseRefreshTokenPath
   );
   if (initialTokens.has_value()) {
     _credentials->seedInitialTokens(initialTokens->accessToken, initialTokens->refreshToken);
@@ -54,6 +55,7 @@ bool DatabaseManager::reopenFromPersistedConfigIfNeeded() {
     configureCredentials(
       creds.provider,
       creds.accessTokenHeaderName,
+      creds.accessTokenScheme,
       creds.refreshEndpoint,
       creds.responseAccessTokenPath,
       creds.responseRefreshTokenPath,

--- a/cpp/database/DatabaseManager.hpp
+++ b/cpp/database/DatabaseManager.hpp
@@ -54,6 +54,7 @@ public:
   void configureCredentials(
     const std::string& provider,
     const std::string& accessTokenHeaderName,
+    const std::string& accessTokenScheme,
     const std::string& refreshEndpoint,
     const std::string& responseAccessTokenPath,
     const std::string& responseRefreshTokenPath,

--- a/cpp/database/NativeConfigStore.cpp
+++ b/cpp/database/NativeConfigStore.cpp
@@ -18,6 +18,7 @@ json::Object serializeCredentials(const PersistedCredentialConfig& creds) {
   json::Object obj;
   obj["provider"] = json::Value(creds.provider);
   obj["accessTokenHeaderName"] = json::Value(creds.accessTokenHeaderName);
+  obj["accessTokenScheme"] = json::Value(creds.accessTokenScheme);
   obj["refreshEndpoint"] = json::Value(creds.refreshEndpoint);
   obj["responseAccessTokenPath"] = json::Value(creds.responseAccessTokenPath);
   obj["responseRefreshTokenPath"] = json::Value(creds.responseRefreshTokenPath);
@@ -39,6 +40,7 @@ std::optional<PersistedCredentialConfig> parseCredentials(const json::Value& roo
   return PersistedCredentialConfig{
     obj.getString("provider"),
     obj.getString("accessTokenHeaderName"),
+    obj.getString("accessTokenScheme", "Bearer"),
     obj.getString("refreshEndpoint"),
     obj.getString("responseAccessTokenPath"),
     obj.getString("responseRefreshTokenPath"),

--- a/cpp/database/NativeConfigStore.hpp
+++ b/cpp/database/NativeConfigStore.hpp
@@ -9,6 +9,7 @@ namespace margelo::nitro::salvedb {
 struct PersistedCredentialConfig {
   std::string provider;
   std::string accessTokenHeaderName;
+  std::string accessTokenScheme;
   std::string refreshEndpoint;
   std::string responseAccessTokenPath;
   std::string responseRefreshTokenPath;

--- a/cpp/tests/HybridSalveDatabaseCredentialsTests.cpp
+++ b/cpp/tests/HybridSalveDatabaseCredentialsTests.cpp
@@ -38,6 +38,7 @@ TEST_CASE("configure() with credentials.tokens seeds the CredentialProvider", "[
     credentials: {
       provider: 'oauth2',
       accessTokenHeaderName: 'Authorization',
+      accessTokenScheme: 'Bearer',
       tokens: { accessToken: 'seeded-access', refreshToken: 'seeded-refresh' },
       refresh: {
         endpoint: '/auth/refresh',
@@ -52,5 +53,5 @@ TEST_CASE("configure() with credentials.tokens seeds the CredentialProvider", "[
 
   auto [headerName, headerValue] = credentials.getAuthHeader();
   REQUIRE(headerName == "Authorization");
-  REQUIRE(headerValue == "seeded-access");
+  REQUIRE(headerValue == "Bearer seeded-access");
 }

--- a/cpp/tests/HybridSalveDatabaseSyncTests.cpp
+++ b/cpp/tests/HybridSalveDatabaseSyncTests.cpp
@@ -44,7 +44,11 @@ TEST_CASE("db.triggerSync() runs a full sync cycle through the real JSI bridge",
   deleteSecureValue("salvedb.credentials.accessToken");
   deleteSecureValue("salvedb.credentials.refreshToken");
 
-  setHttpExecuteResult([](const HttpRequest& request) -> HttpOutcome {
+  std::string capturedAuthHeader;
+  setHttpExecuteResult([&capturedAuthHeader](const HttpRequest& request) -> HttpOutcome {
+    for (auto& [name, value] : request.headers) {
+      if (name == "Authorization") capturedAuthHeader = value;
+    }
     if (request.method == margelo::nitro::salvedb::HttpMethod::Get) return HttpResponse{200, {}, "[]"};
     return HttpResponse{201, {}, *request.body}; // POST: echo the pushed entity back
   });
@@ -57,7 +61,7 @@ TEST_CASE("db.triggerSync() runs a full sync cycle through the real JSI bridge",
     baseUrl: 'https://api.company.com',
     network: { timeout: 5000 },
     credentials: {
-      provider: 'oauth2', accessTokenHeaderName: 'Authorization',
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
       tokens: { accessToken: 'access-1', refreshToken: 'refresh-1' },
       refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
     }
@@ -68,6 +72,7 @@ TEST_CASE("db.triggerSync() runs a full sync cycle through the real JSI bridge",
 
   auto resultJson = harness.run("db.triggerSync('customers', false)");
   REQUIRE(resultJson.find(R"("operationsApplied":1)") != std::string::npos);
+  REQUIRE(capturedAuthHeader == "Bearer access-1"); // real outgoing header, not a mock
 
   auto rows = DatabaseManager::shared().connection()->execute("SELECT COUNT(*) FROM sync_queue WHERE entity = 'customers'", {});
   REQUIRE(std::get<double>(rows.rows[0][0]) == 0.0);
@@ -109,7 +114,7 @@ TEST_CASE("db.triggerSync() refreshes the token on 401 through the real JSI brid
     for (auto& [name, value] : request.headers) {
       if (name == "Authorization") authHeader = value;
     }
-    if (authHeader == "access-1") return HttpResponse{401, {}, "{}"};
+    if (authHeader == "Bearer access-1") return HttpResponse{401, {}, "{}"};
     return HttpResponse{200, {}, "[]"};
   });
 
@@ -121,7 +126,7 @@ TEST_CASE("db.triggerSync() refreshes the token on 401 through the real JSI brid
     baseUrl: 'https://api.company.com',
     network: { timeout: 5000 },
     credentials: {
-      provider: 'oauth2', accessTokenHeaderName: 'Authorization',
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
       tokens: { accessToken: 'access-1', refreshToken: 'refresh-1' },
       refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
     }
@@ -171,7 +176,7 @@ TEST_CASE("db.triggerSyncAll() runs every enabled schema through the real JSI br
     baseUrl: 'https://api.company.com',
     network: { timeout: 5000 },
     credentials: {
-      provider: 'oauth2', accessTokenHeaderName: 'Authorization',
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
       tokens: { accessToken: 'access-1', refreshToken: 'refresh-1' },
       refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
     }

--- a/cpp/tests/credentials/CredentialProviderTests.cpp
+++ b/cpp/tests/credentials/CredentialProviderTests.cpp
@@ -14,10 +14,11 @@ void resetSecureStore() {
   platform::deleteSecureValue("salvedb.credentials.refreshToken");
 }
 
-CredentialProvider makeProvider() {
+CredentialProvider makeProvider(std::string accessTokenScheme = "Bearer") {
   return CredentialProvider(
     "oauth2",
     "Authorization",
+    std::move(accessTokenScheme),
     "/auth/refresh",
     "$.accessToken",
     "$.refreshToken"
@@ -39,6 +40,28 @@ TEST_CASE("seedInitialTokens persists the token pair and getAuthHeader injects i
   provider.seedInitialTokens("access-abc", "refresh-abc");
 
   REQUIRE(provider.getAccessToken().value() == "access-abc");
+  auto [headerName, headerValue] = provider.getAuthHeader();
+  REQUIRE(headerName == "Authorization");
+  REQUIRE(headerValue == "Bearer access-abc");
+}
+
+TEST_CASE("getAuthHeader applies a custom scheme prefix", "[credentials][CredentialProvider]") {
+  resetSecureStore();
+  auto provider = makeProvider("Token");
+
+  provider.seedInitialTokens("access-abc", "refresh-abc");
+
+  auto [headerName, headerValue] = provider.getAuthHeader();
+  REQUIRE(headerName == "Authorization");
+  REQUIRE(headerValue == "Token access-abc");
+}
+
+TEST_CASE("getAuthHeader returns the raw token with no prefix when scheme is empty", "[credentials][CredentialProvider]") {
+  resetSecureStore();
+  auto provider = makeProvider("");
+
+  provider.seedInitialTokens("access-abc", "refresh-abc");
+
   auto [headerName, headerValue] = provider.getAuthHeader();
   REQUIRE(headerName == "Authorization");
   REQUIRE(headerValue == "access-abc");
@@ -110,7 +133,7 @@ TEST_CASE("refresh sends the fixed refreshToken body and persists the new token 
 
   auto [headerName, headerValue] = provider.getAuthHeader();
   REQUIRE(headerName == "Authorization");
-  REQUIRE(headerValue == "access-new");
+  REQUIRE(headerValue == "Bearer access-new");
 }
 
 TEST_CASE("refresh throws a clear error on non-2xx response and does not touch stored tokens", "[credentials][CredentialProvider]") {

--- a/cpp/tests/database/DatabaseManagerReopenTests.cpp
+++ b/cpp/tests/database/DatabaseManagerReopenTests.cpp
@@ -47,6 +47,7 @@ TEST_CASE("reopenFromPersistedConfigIfNeeded rehydrates network, credentials, an
     credentials: {
       provider: 'oauth2',
       accessTokenHeaderName: 'Authorization',
+      accessTokenScheme: 'Token',
       tokens: { accessToken: 'seeded-access', refreshToken: 'seeded-refresh' },
       refresh: {
         endpoint: '/auth/refresh',
@@ -66,6 +67,13 @@ TEST_CASE("reopenFromPersistedConfigIfNeeded rehydrates network, credentials, an
   REQUIRE(DatabaseManager::shared().network().baseUrl == "https://api.company.com");
   REQUIRE(DatabaseManager::shared().network().timeoutMs == 8000.0);
   REQUIRE(DatabaseManager::shared().credentials().getAccessToken().has_value());
+
+  // Proves accessTokenScheme survives the persisted round-trip (a custom
+  // scheme, not just falling back to the "Bearer" default) through a cold
+  // reopen driven purely by NativeConfigStore, without JS ever running.
+  auto [headerName, headerValue] = DatabaseManager::shared().credentials().getAuthHeader();
+  REQUIRE(headerName == "Authorization");
+  REQUIRE(headerValue == "Token seeded-access");
 
   auto background = DatabaseManager::shared().background();
   REQUIRE(background.has_value());

--- a/cpp/tests/database/NativeConfigStoreTests.cpp
+++ b/cpp/tests/database/NativeConfigStoreTests.cpp
@@ -29,7 +29,7 @@ TEST_CASE("NativeConfigStore round-trips every field", "[database][NativeConfigS
   config.baseUrl = "https://api.company.com";
   config.networkTimeoutMs = 9000.0;
   config.credentials = PersistedCredentialConfig{
-    "oauth2", "Authorization", "https://api.company.com/refresh", "$.access_token", "$.refresh_token"
+    "oauth2", "Authorization", "Token", "https://api.company.com/refresh", "$.access_token", "$.refresh_token"
   };
   config.background = BackgroundConfig{900000.0, true, true};
 
@@ -45,6 +45,7 @@ TEST_CASE("NativeConfigStore round-trips every field", "[database][NativeConfigS
   REQUIRE(loaded->credentials.has_value());
   REQUIRE(loaded->credentials->provider == "oauth2");
   REQUIRE(loaded->credentials->accessTokenHeaderName == "Authorization");
+  REQUIRE(loaded->credentials->accessTokenScheme == "Token");
   REQUIRE(loaded->credentials->refreshEndpoint == "https://api.company.com/refresh");
   REQUIRE(loaded->credentials->responseAccessTokenPath == "$.access_token");
   REQUIRE(loaded->credentials->responseRefreshTokenPath == "$.refresh_token");
@@ -87,4 +88,32 @@ TEST_CASE("NativeConfigStore::load returns nullopt for corrupted content", "[dat
   out.close();
 
   REQUIRE_FALSE(NativeConfigStore::load().has_value());
+}
+
+TEST_CASE("NativeConfigStore::load defaults accessTokenScheme to Bearer for a config persisted before it existed", "[database][NativeConfigStore]") {
+  ConfigFileGuard guard;
+
+  // Simulates a config written by an app build predating accessTokenScheme
+  // (issue #104) — load() must not crash and must default it instead of
+  // losing the credentials block on a cold-start reopen.
+  std::ofstream out(configFilePath(), std::ios::binary | std::ios::trunc);
+  out << R"({
+    "dbName": "legacy_db",
+    "walMode": true,
+    "syncOnAppOpen": true,
+    "credentials": {
+      "provider": "oauth2",
+      "accessTokenHeaderName": "Authorization",
+      "refreshEndpoint": "https://api.company.com/refresh",
+      "responseAccessTokenPath": "$.access_token",
+      "responseRefreshTokenPath": "$.refresh_token"
+    }
+  })";
+  out.close();
+
+  auto loaded = NativeConfigStore::load();
+
+  REQUIRE(loaded.has_value());
+  REQUIRE(loaded->credentials.has_value());
+  REQUIRE(loaded->credentials->accessTokenScheme == "Bearer");
 }

--- a/cpp/tests/http/SyncHttpRequesterTests.cpp
+++ b/cpp/tests/http/SyncHttpRequesterTests.cpp
@@ -14,7 +14,7 @@ CredentialProvider testCredentials() {
   platform::deleteSecureValue("salvedb.credentials.accessToken");
   platform::deleteSecureValue("salvedb.credentials.refreshToken");
 
-  CredentialProvider credentials("oauth2", "Authorization", "/auth/refresh", "$.accessToken", "$.refreshToken");
+  CredentialProvider credentials("oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken");
   credentials.seedInitialTokens("access-1", "refresh-1");
   return credentials;
 }
@@ -55,7 +55,7 @@ TEST_CASE("refreshes the token on 401 and reexecutes the call", "[http][SyncHttp
     for (auto& [name, value] : request.headers) {
       if (name == "Authorization") authHeader = value;
     }
-    if (authHeader == "access-1") return HttpResponse{401, {}, "{}"};
+    if (authHeader == "Bearer access-1") return HttpResponse{401, {}, "{}"};
     return HttpResponse{200, {}, "[]"};
   });
 
@@ -79,7 +79,7 @@ TEST_CASE("a 401 refresh does not eat into the retry budget for a subsequent net
     for (auto& [name, value] : request.headers) {
       if (name == "Authorization") authHeader = value;
     }
-    if (authHeader == "access-1") return HttpResponse{401, {}, "{}"};
+    if (authHeader == "Bearer access-1") return HttpResponse{401, {}, "{}"};
     ++networkAttempts;
     return HttpNetworkError{HttpNetworkErrorKind::NoConnection, "no connection"};
   });
@@ -93,7 +93,7 @@ TEST_CASE("a 401 refresh does not eat into the retry budget for a subsequent net
 }
 
 TEST_CASE("a credential lookup failure comes back as HttpNetworkError, not a thrown exception", "[http][SyncHttpRequester]") {
-  CredentialProvider credentials("oauth2", "Authorization", "/auth/refresh", "$.accessToken", "$.refreshToken");
+  CredentialProvider credentials("oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken");
   // No seedInitialTokens() call — getAuthHeader() throws with no token stored.
   SyncHttpRequester requester(credentials, testNetwork());
 

--- a/cpp/tests/sync/SyncNativeEntryPointTests.cpp
+++ b/cpp/tests/sync/SyncNativeEntryPointTests.cpp
@@ -34,7 +34,7 @@ void openSyncFixture(const std::string& testName) {
   })"));
 
   DatabaseManager::shared().configureCredentials(
-    "oauth2", "Authorization", "/auth/refresh", "$.accessToken", "$.refreshToken",
+    "oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken",
     InitialCredentialTokens{"access-1", "refresh-1"}
   );
   DatabaseManager::shared().configureNetwork("https://api.company.com", 5000.0);

--- a/cpp/tests/sync/SyncOrchestratorTests.cpp
+++ b/cpp/tests/sync/SyncOrchestratorTests.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<SQLiteConnection> openOrchestratorFixture(
   })"));
 
   DatabaseManager::shared().configureCredentials(
-    "oauth2", "Authorization", "/auth/refresh", "$.accessToken", "$.refreshToken",
+    "oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken",
     InitialCredentialTokens{"access-1", "refresh-1"}
   );
   DatabaseManager::shared().configureNetwork("https://api.company.com", 5000.0);
@@ -941,7 +941,7 @@ TEST_CASE("a pre-#84 opaque cursor is reset on registration; the first pull star
   })"));
 
   DatabaseManager::shared().configureCredentials(
-    "oauth2", "Authorization", "/auth/refresh", "$.accessToken", "$.refreshToken",
+    "oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken",
     InitialCredentialTokens{"access-1", "refresh-1"}
   );
   DatabaseManager::shared().configureNetwork("https://api.company.com", 5000.0);

--- a/nitrogen/generated/shared/c++/CredentialsParams.hpp
+++ b/nitrogen/generated/shared/c++/CredentialsParams.hpp
@@ -47,12 +47,13 @@ namespace margelo::nitro::salvedb {
   public:
     std::string provider     SWIFT_PRIVATE;
     std::string accessTokenHeaderName     SWIFT_PRIVATE;
+    std::string accessTokenScheme     SWIFT_PRIVATE;
     std::optional<InitialTokensParams> tokens     SWIFT_PRIVATE;
     RefreshParams refresh     SWIFT_PRIVATE;
 
   public:
     CredentialsParams() = default;
-    explicit CredentialsParams(std::string provider, std::string accessTokenHeaderName, std::optional<InitialTokensParams> tokens, RefreshParams refresh): provider(provider), accessTokenHeaderName(accessTokenHeaderName), tokens(tokens), refresh(refresh) {}
+    explicit CredentialsParams(std::string provider, std::string accessTokenHeaderName, std::string accessTokenScheme, std::optional<InitialTokensParams> tokens, RefreshParams refresh): provider(provider), accessTokenHeaderName(accessTokenHeaderName), accessTokenScheme(accessTokenScheme), tokens(tokens), refresh(refresh) {}
 
   public:
     friend bool operator==(const CredentialsParams& lhs, const CredentialsParams& rhs) = default;
@@ -70,6 +71,7 @@ namespace margelo::nitro {
       return margelo::nitro::salvedb::CredentialsParams(
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "provider"))),
         JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accessTokenHeaderName"))),
+        JSIConverter<std::string>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accessTokenScheme"))),
         JSIConverter<std::optional<margelo::nitro::salvedb::InitialTokensParams>>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "tokens"))),
         JSIConverter<margelo::nitro::salvedb::RefreshParams>::fromJSI(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "refresh")))
       );
@@ -78,6 +80,7 @@ namespace margelo::nitro {
       jsi::Object obj(runtime);
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "provider"), JSIConverter<std::string>::toJSI(runtime, arg.provider));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "accessTokenHeaderName"), JSIConverter<std::string>::toJSI(runtime, arg.accessTokenHeaderName));
+      obj.setProperty(runtime, PropNameIDCache::get(runtime, "accessTokenScheme"), JSIConverter<std::string>::toJSI(runtime, arg.accessTokenScheme));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "tokens"), JSIConverter<std::optional<margelo::nitro::salvedb::InitialTokensParams>>::toJSI(runtime, arg.tokens));
       obj.setProperty(runtime, PropNameIDCache::get(runtime, "refresh"), JSIConverter<margelo::nitro::salvedb::RefreshParams>::toJSI(runtime, arg.refresh));
       return obj;
@@ -92,6 +95,7 @@ namespace margelo::nitro {
       }
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "provider")))) return false;
       if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accessTokenHeaderName")))) return false;
+      if (!JSIConverter<std::string>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "accessTokenScheme")))) return false;
       if (!JSIConverter<std::optional<margelo::nitro::salvedb::InitialTokensParams>>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "tokens")))) return false;
       if (!JSIConverter<margelo::nitro::salvedb::RefreshParams>::canConvert(runtime, obj.getProperty(runtime, PropNameIDCache::get(runtime, "refresh")))) return false;
       return true;

--- a/src/database/classes/ConfigureDb/library/__tests__/mapCredentials.test.ts
+++ b/src/database/classes/ConfigureDb/library/__tests__/mapCredentials.test.ts
@@ -2,7 +2,7 @@ import { mapCredentials } from '../mapCredentials';
 import type { ICredentialsDefinition } from '../../types';
 
 describe('mapCredentials', () => {
-  test('maps oauth2 credentials, defaulting accessTokenHeaderName to Authorization', () => {
+  test('maps oauth2 credentials, defaulting accessTokenHeaderName to Authorization and accessTokenScheme to Bearer', () => {
     const creds: ICredentialsDefinition = {
       provider: 'oauth2',
       tokens: { accessToken: 'access', refreshToken: 'refresh' },
@@ -15,6 +15,7 @@ describe('mapCredentials', () => {
     expect(mapCredentials(creds)).toEqual({
       provider: 'oauth2',
       accessTokenHeaderName: 'Authorization',
+      accessTokenScheme: 'Bearer',
       tokens: { accessToken: 'access', refreshToken: 'refresh' },
       refresh: {
         endpoint: '/auth/refresh',
@@ -35,5 +36,31 @@ describe('mapCredentials', () => {
     };
 
     expect(mapCredentials(creds)?.accessTokenHeaderName).toBe('X-Api-Token');
+  });
+
+  test('honors a custom accessToken.scheme', () => {
+    const creds: ICredentialsDefinition = {
+      provider: 'oauth2',
+      accessToken: { scheme: 'Token' },
+      refresh: {
+        endpoint: '/auth/refresh',
+        response: { accessToken: '$.accessToken', refreshToken: '$.refreshToken' },
+      },
+    };
+
+    expect(mapCredentials(creds)?.accessTokenScheme).toBe('Token');
+  });
+
+  test('honors an empty accessToken.scheme for APIs expecting the raw token with no prefix', () => {
+    const creds: ICredentialsDefinition = {
+      provider: 'oauth2',
+      accessToken: { scheme: '' },
+      refresh: {
+        endpoint: '/auth/refresh',
+        response: { accessToken: '$.accessToken', refreshToken: '$.refreshToken' },
+      },
+    };
+
+    expect(mapCredentials(creds)?.accessTokenScheme).toBe('');
   });
 });

--- a/src/database/classes/ConfigureDb/library/mapCredentials.ts
+++ b/src/database/classes/ConfigureDb/library/mapCredentials.ts
@@ -7,6 +7,7 @@ export function mapCredentials(creds: ICredentialsDefinition): ConfigureParams['
       return {
         provider: creds.provider,
         accessTokenHeaderName: creds.accessToken?.headerName ?? 'Authorization',
+        accessTokenScheme: creds.accessToken?.scheme ?? 'Bearer',
         tokens: creds.tokens,
         refresh: {
           endpoint: creds.refresh.endpoint,

--- a/src/database/classes/ConfigureDb/types/ICredentialsDefinition.ts
+++ b/src/database/classes/ConfigureDb/types/ICredentialsDefinition.ts
@@ -2,9 +2,16 @@ import type { JsonPath } from "../../../../types";
 
 interface OAuth2CredentialsDefinition {
   provider: 'oauth2';
-  /** Where the access token travels in sync requests. @default "Authorization" */
+  /** Where the access token travels in sync requests, and the scheme prefix applied to it. */
   accessToken?: {
+    /** Header used to send the access token in sync requests. @default "Authorization" */
     headerName?: string;
+    /**
+     * Prefix applied to the token in the header value (e.g. `Authorization: Bearer <token>`).
+     * Pass `""` for APIs that expect the raw token with no scheme prefix.
+     * @default "Bearer"
+     */
+    scheme?: string;
   };
   /**
    * Initial token pair, obtained by the app's own login flow (out of scope

--- a/src/specs/types/ConfigureParams.ts
+++ b/src/specs/types/ConfigureParams.ts
@@ -35,6 +35,8 @@ interface CredentialsParams {
   provider: string;
   /** Header used to send the access token in sync requests (e.g. `"Authorization"`). */
   accessTokenHeaderName: string;
+  /** Scheme prefix applied to the token in the header value (e.g. `"Bearer"`). Empty string means no prefix. */
+  accessTokenScheme: string;
   /**
    * Initial token pair obtained by the app's own login flow. Seeded into
    * Keychain/Keystore once at configure() time; omitted on later configure()


### PR DESCRIPTION
## Summary

- `CredentialProvider::getAuthHeader()` sent the raw access token with no auth-scheme prefix, so every sync request went out as `Authorization: <token>` instead of the RFC 6750 `Authorization: Bearer <token>` real OAuth2 APIs expect — breaking sync against virtually any real-world Bearer-auth REST API.
- Adds `accessTokenScheme` (default `"Bearer"`, empty string opts out of a prefix) threaded end-to-end: `ICredentialsDefinition.accessToken.scheme` → `mapCredentials` → Nitro `CredentialsParams` → `DatabaseManager` → `CredentialProvider.getAuthHeader()`.
- Persisted in `NativeConfigStore` for the native background-wake cold-start reopen path, with a `getString(key, "Bearer")` fallback so a config file written before this change doesn't crash on load.

## Test plan

- [x] `npm run test:native` — 265 test cases / 694 assertions pass (new cases cover default `Bearer`, custom scheme, empty scheme, and a real-JSI e2e assertion on the actual outgoing `Authorization` header value)
- [x] `npx jest` — 163 tests / 20 suites pass, including `mapCredentials` default/override/empty-scheme cases
- [x] `npx tsc --noEmit` — clean
- [x] `npm run codegen` — nitrogen regenerated `CredentialsParams.hpp` with the new field, build clean

Closes #104