### PR TITLE
feat(sync): configurable conflict field, serverWins/clientWins strategies

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,7 +55,7 @@ Read sync_queue (up to pageSize)
 | Area | Decision |
 |---|---|
 | Sync strategy | `operations` only (queue-based diff via triggers) |
-| Conflict | `lastWriteWins` only (compares `updatedAt`) |
+| Conflict | `lastWriteWins` (configurable `field`, default `updatedAt`), `serverWins`, `clientWins` — `manual` not implemented |
 | Transport | REST only |
 | Direction | `bidirectional` only |
 | Auth | Single global OAuth2 (`Database.configure`) — no per-schema override |

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -2,6 +2,7 @@
 #include "json_parser.hpp"
 #include "SchemaRegistry.hpp"
 #include "SalveMetadataManager.hpp"
+#include "../sync/SyncContract.hpp"
 #include "../sync/SyncDefinitionStore.hpp"
 #include "../sync/SyncCursorStore.hpp"
 
@@ -585,14 +586,37 @@ SchemaDef MigrationEngine::parseSchemaJson(const std::string& jsonStr) {
     schema.sync.definition = syncObj;
 
     if (schema.sync.enabled) {
-      auto updatedAt = schema.columns.find("updatedAt");
-      bool valid = updatedAt != schema.columns.end()
-        && updatedAt->second.type == "datetime"
-        && !updatedAt->second.nullable;
-      if (!valid) {
+      std::string conflictStrategy = "lastWriteWins";
+      std::string conflictField = "updatedAt";
+      bool conflictFieldExplicit = false;
+      auto conflictVal = syncObj.get("conflict");
+      if (conflictVal && conflictVal->get().isObject()) {
+        conflictStrategy = conflictVal->get().getString("strategy", "lastWriteWins");
+        conflictFieldExplicit = conflictVal->get().has("field");
+        conflictField = conflictVal->get().getString("field", "updatedAt");
+      }
+
+      if (!isValidConflictStrategy(conflictStrategy)) {
         throw std::runtime_error(
-          "registerSchema: sync.enabled requires a NOT NULL 'datetime' column named 'updatedAt' (used for lastWriteWins)"
+          "registerSchema: sync.conflict.strategy '" + conflictStrategy + "' is not supported"
         );
+      }
+
+      if (conflictStrategy == "lastWriteWins") {
+        auto field = schema.columns.find(conflictField);
+        bool valid = field != schema.columns.end()
+          && field->second.type == "datetime"
+          && !field->second.nullable;
+        if (!valid) {
+          std::string hint = conflictFieldExplicit
+            ? "" // the developer already chose this name — nothing more to suggest
+            : " ('" + conflictField + "' is the default when sync.conflict.field is not set — "
+              "pass a different sync.conflict.field to use another column instead)";
+          throw std::runtime_error(
+            "registerSchema: sync.conflict.strategy 'lastWriteWins' requires a NOT NULL 'datetime' column named '" +
+            conflictField + "'" + hint
+          );
+        }
       }
     }
   }

--- a/cpp/database/MigrationEngine.cpp
+++ b/cpp/database/MigrationEngine.cpp
@@ -586,35 +586,27 @@ SchemaDef MigrationEngine::parseSchemaJson(const std::string& jsonStr) {
     schema.sync.definition = syncObj;
 
     if (schema.sync.enabled) {
-      std::string conflictStrategy = "lastWriteWins";
-      std::string conflictField = "updatedAt";
-      bool conflictFieldExplicit = false;
-      auto conflictVal = syncObj.get("conflict");
-      if (conflictVal && conflictVal->get().isObject()) {
-        conflictStrategy = conflictVal->get().getString("strategy", "lastWriteWins");
-        conflictFieldExplicit = conflictVal->get().has("field");
-        conflictField = conflictVal->get().getString("field", "updatedAt");
-      }
+      SyncConflict conflict = readConflictDefaults(syncObj);
 
-      if (!isValidConflictStrategy(conflictStrategy)) {
+      if (!isValidConflictStrategy(conflict.strategy)) {
         throw std::runtime_error(
-          "registerSchema: sync.conflict.strategy '" + conflictStrategy + "' is not supported"
+          "registerSchema: sync.conflict.strategy '" + conflict.strategy + "' is not supported"
         );
       }
 
-      if (conflictStrategy == "lastWriteWins") {
-        auto field = schema.columns.find(conflictField);
+      if (conflict.strategy == "lastWriteWins") {
+        auto field = schema.columns.find(conflict.field);
         bool valid = field != schema.columns.end()
           && field->second.type == "datetime"
           && !field->second.nullable;
         if (!valid) {
-          std::string hint = conflictFieldExplicit
+          std::string hint = conflict.fieldExplicit
             ? "" // the developer already chose this name — nothing more to suggest
-            : " ('" + conflictField + "' is the default when sync.conflict.field is not set — "
+            : " ('" + conflict.field + "' is the default when sync.conflict.field is not set — "
               "pass a different sync.conflict.field to use another column instead)";
           throw std::runtime_error(
             "registerSchema: sync.conflict.strategy 'lastWriteWins' requires a NOT NULL 'datetime' column named '" +
-            conflictField + "'" + hint
+            conflict.field + "'" + hint
           );
         }
       }

--- a/cpp/sync/SyncContract.cpp
+++ b/cpp/sync/SyncContract.cpp
@@ -25,20 +25,11 @@ HttpHeaders parseExtraHeaders(const json::Value& endpoint) {
   return headers;
 }
 
-// Absent, or not an object (a pre-#103-style `conflict: "lastWriteWins"`
-// string persisted by a version of the library predating this struct) —
-// both fall back to the pre-existing hardcoded behavior instead of failing
-// a cold-start reopen on stale persisted config.
 SyncConflict parseConflict(const json::Value& definition) {
-  SyncConflict conflict;
-  auto raw = definition.get("conflict");
-  if (!raw || !raw->get().isObject()) return conflict;
-
-  conflict.strategy = raw->get().getString("strategy", "lastWriteWins");
+  SyncConflict conflict = readConflictDefaults(definition);
   if (!isValidConflictStrategy(conflict.strategy)) {
     throw std::runtime_error("SyncContract: sync.conflict.strategy '" + conflict.strategy + "' is not supported");
   }
-  conflict.field = raw->get().getString("field", "updatedAt");
   return conflict;
 }
 
@@ -49,6 +40,17 @@ bool isValidConflictStrategy(const std::string& strategy) {
     "lastWriteWins", "serverWins", "clientWins"
   };
   return kValidConflictStrategies.count(strategy) > 0;
+}
+
+SyncConflict readConflictDefaults(const json::Value& definition) {
+  SyncConflict conflict;
+  auto raw = definition.get("conflict");
+  if (!raw || !raw->get().isObject()) return conflict;
+
+  conflict.strategy = raw->get().getString("strategy", "lastWriteWins");
+  conflict.fieldExplicit = raw->get().has("field");
+  conflict.field = raw->get().getString("field", "updatedAt");
+  return conflict;
 }
 
 SyncContract SyncContract::fromDefinition(const json::Value& definition) {

--- a/cpp/sync/SyncContract.cpp
+++ b/cpp/sync/SyncContract.cpp
@@ -1,5 +1,6 @@
 #include "SyncContract.hpp"
 #include <stdexcept>
+#include <unordered_set>
 
 namespace margelo::nitro::salvedb {
 
@@ -24,7 +25,31 @@ HttpHeaders parseExtraHeaders(const json::Value& endpoint) {
   return headers;
 }
 
+// Absent, or not an object (a pre-#103-style `conflict: "lastWriteWins"`
+// string persisted by a version of the library predating this struct) —
+// both fall back to the pre-existing hardcoded behavior instead of failing
+// a cold-start reopen on stale persisted config.
+SyncConflict parseConflict(const json::Value& definition) {
+  SyncConflict conflict;
+  auto raw = definition.get("conflict");
+  if (!raw || !raw->get().isObject()) return conflict;
+
+  conflict.strategy = raw->get().getString("strategy", "lastWriteWins");
+  if (!isValidConflictStrategy(conflict.strategy)) {
+    throw std::runtime_error("SyncContract: sync.conflict.strategy '" + conflict.strategy + "' is not supported");
+  }
+  conflict.field = raw->get().getString("field", "updatedAt");
+  return conflict;
+}
+
 } // namespace
+
+bool isValidConflictStrategy(const std::string& strategy) {
+  static const std::unordered_set<std::string> kValidConflictStrategies = {
+    "lastWriteWins", "serverWins", "clientWins"
+  };
+  return kValidConflictStrategies.count(strategy) > 0;
+}
 
 SyncContract SyncContract::fromDefinition(const json::Value& definition) {
   auto endpointVal = definition.get("endpoint");
@@ -38,6 +63,8 @@ SyncContract SyncContract::fromDefinition(const json::Value& definition) {
   contract.endpoint.sinceParam = requireString(endpoint, "sinceParam");
   contract.endpoint.limitParam = requireString(endpoint, "limitParam");
   contract.endpoint.extraHeaders = parseExtraHeaders(endpoint);
+  contract.endpoint.cursorField = endpoint.getString("cursorField", "updatedAt");
+  contract.conflict = parseConflict(definition);
 
   auto pagination = definition.get("pagination");
   if (pagination) {

--- a/cpp/sync/SyncContract.hpp
+++ b/cpp/sync/SyncContract.hpp
@@ -24,6 +24,7 @@ struct SyncEndpoint {
 struct SyncConflict {
   std::string strategy = "lastWriteWins";
   std::string field = "updatedAt";
+  bool fieldExplicit = false;
 };
 
 // Typed, validated view of a schema's declarative `sync` block (REST contract, #84).
@@ -40,5 +41,7 @@ struct SyncContract {
 // shared by SyncContract's own parsing and MigrationEngine::registerSchema's
 // eager validation, so the two never drift apart.
 bool isValidConflictStrategy(const std::string& strategy);
+
+SyncConflict readConflictDefaults(const json::Value& syncDefinition);
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncContract.hpp
+++ b/cpp/sync/SyncContract.hpp
@@ -11,15 +11,34 @@ struct SyncEndpoint {
   std::string sinceParam;
   std::string limitParam;
   HttpHeaders extraHeaders;
+  // Per-row JSON field carrying that row's timestamp, read from the last row
+  // of a pulled page to advance the incremental-pull cursor. Required
+  // regardless of conflict strategy — pagination, not conflict resolution.
+  std::string cursorField = "updatedAt";
+};
+
+// `field` only applies to `lastWriteWins` — the NOT NULL datetime column
+// (local schema and API payload alike) compared to resolve pull conflicts.
+// Configurable so an API's own timestamp field name can be used instead of
+// forcing `updatedAt`.
+struct SyncConflict {
+  std::string strategy = "lastWriteWins";
+  std::string field = "updatedAt";
 };
 
 // Typed, validated view of a schema's declarative `sync` block (REST contract, #84).
 struct SyncContract {
   SyncEndpoint endpoint;
+  SyncConflict conflict;
   int pageSize = 20;
   int maxPagesPerSession = 20;
 
   static SyncContract fromDefinition(const json::Value& definition);
 };
+
+// Single source of truth for the supported `sync.conflict.strategy` values —
+// shared by SyncContract's own parsing and MigrationEngine::registerSchema's
+// eager validation, so the two never drift apart.
+bool isValidConflictStrategy(const std::string& strategy);
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncOperationApplier.cpp
+++ b/cpp/sync/SyncOperationApplier.cpp
@@ -46,8 +46,8 @@ int64_t nowMillis() {
 
 } // namespace
 
-SyncOperationApplier::SyncOperationApplier(std::shared_ptr<SQLiteConnection> conn)
-  : _conn(std::move(conn)) {}
+SyncOperationApplier::SyncOperationApplier(std::shared_ptr<SQLiteConnection> conn, SyncConflict conflict)
+  : _conn(std::move(conn)), _conflict(std::move(conflict)) {}
 
 const SyncOperationApplier::TableColumns& SyncOperationApplier::columnsFor(const std::string& table) {
   auto it = _columnsCache.find(table);
@@ -88,19 +88,32 @@ ApplyStats SyncOperationApplier::apply(const std::string& expectedEntity, const 
     std::string pkValue = jsonScalarToString(pkRef->get());
 
     auto deletedAt = readOptionalNumber(row, "deletedAt");
-    auto updatedAt = readOptionalNumber(row, "updatedAt");
+    auto updatedAt = readOptionalNumber(row, _conflict.field);
     double remoteTimestamp = deletedAt.value_or(updatedAt.value_or(0));
 
-    auto existing = _conn->execute(
-      "SELECT updatedAt FROM \"" + expectedEntity + "\" WHERE \"" + pkCol + "\" = ?",
-      { pkValue }
-    );
-    std::optional<double> localUpdatedAt;
-    if (!existing.rows.empty()) localUpdatedAt = std::get<double>(existing.rows[0][0]);
+    bool exists;
+    std::optional<double> localTimestamp; // only meaningful for lastWriteWins
+    if (_conflict.strategy == "lastWriteWins") {
+      auto existing = _conn->execute(
+        "SELECT \"" + _conflict.field + "\" FROM \"" + expectedEntity + "\" WHERE \"" + pkCol + "\" = ?",
+        { pkValue }
+      );
+      exists = !existing.rows.empty();
+      if (exists) localTimestamp = std::get<double>(existing.rows[0][0]);
+    } else {
+      auto existing = _conn->execute(
+        "SELECT 1 FROM \"" + expectedEntity + "\" WHERE \"" + pkCol + "\" = ?",
+        { pkValue }
+      );
+      exists = !existing.rows.empty();
+    }
 
-    // Tombstone: soft-delete locally if the row exists and isn't newer than the server's delete.
+    // Tombstone: soft-delete locally per the configured conflict strategy.
     if (deletedAt.has_value()) {
-      if (localUpdatedAt.has_value() && remoteTimestamp > *localUpdatedAt) {
+      bool shouldDelete = _conflict.strategy == "serverWins" ? exists
+        : _conflict.strategy == "clientWins" ? false
+        : exists && remoteTimestamp > *localTimestamp; // lastWriteWins
+      if (shouldDelete) {
         _conn->execute(
           "UPDATE \"" + expectedEntity + "\" SET \"deletedAt\" = ? WHERE \"" + pkCol + "\" = ?",
           { *deletedAt, pkValue }
@@ -111,8 +124,10 @@ ApplyStats SyncOperationApplier::apply(const std::string& expectedEntity, const 
       continue;
     }
 
-    // lastWriteWins: skip if the incoming write is not newer than local.
-    if (localUpdatedAt.has_value() && remoteTimestamp <= *localUpdatedAt) continue;
+    bool shouldApply = _conflict.strategy == "serverWins" ? true
+      : _conflict.strategy == "clientWins" ? !exists
+      : !exists || remoteTimestamp > *localTimestamp; // lastWriteWins
+    if (!shouldApply) continue;
 
     std::vector<std::string> columns;
     std::vector<SqlValue> values;
@@ -124,7 +139,7 @@ ApplyStats SyncOperationApplier::apply(const std::string& expectedEntity, const 
     }
 
     std::ostringstream sql;
-    if (!localUpdatedAt.has_value()) {
+    if (!exists) {
       sql << "INSERT INTO \"" << expectedEntity << "\" (";
       for (size_t i = 0; i < columns.size(); ++i) { if (i) sql << ", "; sql << "\"" << columns[i] << "\""; }
       sql << ") VALUES (";
@@ -199,13 +214,17 @@ void SyncOperationApplier::rewriteLocalRow(const std::string& expectedEntity, co
     );
   }
 
-  // The other columns are data: a concurrent local edit during this request's round-trip must win (lastWriteWins, mirroring apply()'s pull-side rule).
+  // The other columns are data: a concurrent local edit during this request's round-trip must win (lastWriteWins, mirroring apply()'s pull-side rule) — always, regardless of the schema's overall conflict strategy.
   if (!columns.empty()) {
-    auto responseUpdatedAt = readOptionalNumber(responseEntity, "updatedAt");
+    // A serverWins/clientWins schema isn't required to declare `_conflict.field` as a
+    // column — skip the guard entirely rather than SELECTing a column that may not exist.
+    auto responseUpdatedAt = cols.all.count(_conflict.field) > 0
+      ? readOptionalNumber(responseEntity, _conflict.field)
+      : std::nullopt;
     bool shouldApplyData = true;
     if (responseUpdatedAt.has_value()) {
       auto current = _conn->execute(
-        "SELECT updatedAt FROM \"" + expectedEntity + "\" WHERE \"" + cols.primaryKey + "\" = ?",
+        "SELECT \"" + _conflict.field + "\" FROM \"" + expectedEntity + "\" WHERE \"" + cols.primaryKey + "\" = ?",
         { identity.resolvedEntityId }
       );
       if (!current.rows.empty()) {

--- a/cpp/sync/SyncOperationApplier.cpp
+++ b/cpp/sync/SyncOperationApplier.cpp
@@ -216,19 +216,20 @@ void SyncOperationApplier::rewriteLocalRow(const std::string& expectedEntity, co
 
   // The other columns are data: a concurrent local edit during this request's round-trip must win (lastWriteWins, mirroring apply()'s pull-side rule) — always, regardless of the schema's overall conflict strategy.
   if (!columns.empty()) {
-    // A serverWins/clientWins schema isn't required to declare `_conflict.field` as a
-    // column — skip the guard entirely rather than SELECTing a column that may not exist.
-    auto responseUpdatedAt = cols.all.count(_conflict.field) > 0
-      ? readOptionalNumber(responseEntity, _conflict.field)
-      : std::nullopt;
-    bool shouldApplyData = true;
-    if (responseUpdatedAt.has_value()) {
-      auto current = _conn->execute(
-        "SELECT \"" + _conflict.field + "\" FROM \"" + expectedEntity + "\" WHERE \"" + cols.primaryKey + "\" = ?",
-        { identity.resolvedEntityId }
-      );
-      if (!current.rows.empty()) {
-        shouldApplyData = std::get<double>(current.rows[0][0]) <= *responseUpdatedAt;
+    bool shouldApplyData;
+    if (cols.all.count(_conflict.field) == 0) {
+      shouldApplyData = false;
+    } else {
+      shouldApplyData = true;
+      auto responseUpdatedAt = readOptionalNumber(responseEntity, _conflict.field);
+      if (responseUpdatedAt.has_value()) {
+        auto current = _conn->execute(
+          "SELECT \"" + _conflict.field + "\" FROM \"" + expectedEntity + "\" WHERE \"" + cols.primaryKey + "\" = ?",
+          { identity.resolvedEntityId }
+        );
+        if (!current.rows.empty()) {
+          shouldApplyData = std::get<double>(current.rows[0][0]) <= *responseUpdatedAt;
+        }
       }
     }
     if (shouldApplyData) {

--- a/cpp/sync/SyncOperationApplier.hpp
+++ b/cpp/sync/SyncOperationApplier.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SyncContract.hpp"
 #include "../database/SQLiteConnection.hpp"
 #include "../database/json_parser.hpp"
 #include <memory>
@@ -16,12 +17,12 @@ struct ApplyStats {
 };
 
 // Plain C++ collaborator (not a HybridObject) — applies REST sync results to
-// SQLite, resolving conflicts via lastWriteWins on `updatedAt`. Must run
-// inside SyncApplyGuard's bypass transaction so it never re-enqueues into
-// sync_queue.
+// SQLite, resolving pull conflicts per the schema's configured strategy
+// (lastWriteWins/serverWins/clientWins). Must run inside SyncApplyGuard's
+// bypass transaction so it never re-enqueues into sync_queue.
 class SyncOperationApplier {
 public:
-  explicit SyncOperationApplier(std::shared_ptr<SQLiteConnection> conn);
+  explicit SyncOperationApplier(std::shared_ptr<SQLiteConnection> conn, SyncConflict conflict = {});
 
   // Pull: applies a page of bare entities. deletedAt != null is a tombstone
   // (soft-deletes locally); everything else infers insert vs update by
@@ -56,6 +57,7 @@ private:
 
   std::shared_ptr<SQLiteConnection> _conn;
   std::unordered_map<std::string, TableColumns> _columnsCache;
+  SyncConflict _conflict;
 };
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/sync/SyncOrchestrator.cpp
+++ b/cpp/sync/SyncOrchestrator.cpp
@@ -53,7 +53,7 @@ NativeSyncResult SyncOrchestrator::runSyncSession(const std::string& schemaName)
   SyncQueueStore queue(conn);
   SyncApplyGuard guard(conn);
   SyncCursorStore cursors(conn);
-  SyncOperationApplier applier(conn);
+  SyncOperationApplier applier(conn, contract.conflict);
 
   double start = nowMillis();
 

--- a/cpp/sync/SyncPullPhase.cpp
+++ b/cpp/sync/SyncPullPhase.cpp
@@ -18,15 +18,15 @@ int64_t parseCursor(const std::optional<std::string>& stored) {
   }
 }
 
-// (last row's deletedAt ?? updatedAt) - 1ms — since is exclusive server-side, so the 1ms overlap gets re-delivered (a no-op via lastWriteWins) instead of skipped.
-int64_t candidateCursorFor(const json::Value& lastRow) {
+// (last row's deletedAt ?? endpoint.cursorField) - 1ms — since is exclusive server-side, so the 1ms overlap gets re-delivered (a no-op via lastWriteWins) instead of skipped.
+int64_t candidateCursorFor(const json::Value& lastRow, const std::string& cursorField) {
   auto deletedAt = lastRow.get("deletedAt");
   bool hasDeletedAt = deletedAt && deletedAt->get().isNumber();
-  auto updatedAt = lastRow.get("updatedAt");
+  auto updatedAt = lastRow.get(cursorField);
   bool hasUpdatedAt = updatedAt && updatedAt->get().isNumber();
   if (!hasDeletedAt && !hasUpdatedAt) {
     throw std::runtime_error(
-      "SyncPullPhase: last row of a pulled page has no numeric updatedAt or deletedAt — cannot advance the cursor"
+      "SyncPullPhase: last row of a pulled page has no numeric '" + cursorField + "' or deletedAt — cannot advance the cursor"
     );
   }
   double lastTimestamp = hasDeletedAt ? deletedAt->get().asNumber() : updatedAt->get().asNumber();
@@ -71,7 +71,7 @@ PullPhaseResult runPullPhase(const std::string& entity, const SyncContract& cont
       result.pagesFetched++;
       if (rows.empty()) break;
 
-      candidateCursor = candidateCursorFor(rows.back());
+      candidateCursor = candidateCursorFor(rows.back(), contract.endpoint.cursorField);
       bool wasFull = static_cast<int>(rows.size()) == limit;
       if (candidateCursor > sinceMs || !wasFull) break;
 

--- a/cpp/tests/database/MigrationEngineTests.cpp
+++ b/cpp/tests/database/MigrationEngineTests.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include "../../database/MigrationEngine.hpp"
 #include "../../database/SQLiteConnection.hpp"
 #include "../../platform/platform.hpp"
@@ -7,6 +8,7 @@
 #include <vector>
 
 using namespace margelo::nitro::salvedb;
+using Catch::Matchers::ContainsSubstring;
 
 namespace {
 
@@ -435,6 +437,65 @@ TEST_CASE("sync.enabled: true without a datetime 'updatedAt' column throws", "[m
     "columns": { "id": { "type": "integer" }, "updatedAt": { "type": "datetime", "nullable": false } },
     "sync": { "enabled": true }
   })"));
+}
+
+TEST_CASE("sync.conflict.strategy 'lastWriteWins' with a custom field requires that column, not 'updatedAt'", "[migration][sync]") {
+  // Custom field declared, but the actual column is still named "updatedAt" — must throw.
+  CHECK_THROWS_AS(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "updatedAt": { "type": "datetime", "nullable": false } },
+    "sync": { "enabled": true, "conflict": { "strategy": "lastWriteWins", "field": "modifiedAt" } }
+  })"), std::runtime_error);
+
+  CHECK_NOTHROW(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "modifiedAt": { "type": "datetime", "nullable": false } },
+    "sync": { "enabled": true, "conflict": { "strategy": "lastWriteWins", "field": "modifiedAt" } }
+  })"));
+}
+
+TEST_CASE("the missing-column error explains 'updatedAt' is only the default, when 'field' was never set", "[migration][sync]") {
+  REQUIRE_THROWS_WITH(
+    MigrationEngine::parseSchemaJson(R"({
+      "name": "customers", "version": 1, "primaryKey": "id",
+      "columns": { "id": { "type": "integer" } },
+      "sync": { "enabled": true }
+    })"),
+    ContainsSubstring("is the default when sync.conflict.field is not set")
+  );
+}
+
+TEST_CASE("the missing-column error does not suggest a default when 'field' was explicitly set", "[migration][sync]") {
+  REQUIRE_THROWS_WITH(
+    MigrationEngine::parseSchemaJson(R"({
+      "name": "customers", "version": 1, "primaryKey": "id",
+      "columns": { "id": { "type": "integer" } },
+      "sync": { "enabled": true, "conflict": { "strategy": "lastWriteWins", "field": "modifiedAt" } }
+    })"),
+    !ContainsSubstring("is the default when sync.conflict.field is not set")
+  );
+}
+
+TEST_CASE("sync.conflict.strategy 'serverWins'/'clientWins' require no timestamp column at all", "[migration][sync]") {
+  CHECK_NOTHROW(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" } },
+    "sync": { "enabled": true, "conflict": { "strategy": "serverWins" } }
+  })"));
+
+  CHECK_NOTHROW(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "name": { "type": "text" } },
+    "sync": { "enabled": true, "conflict": { "strategy": "clientWins" } }
+  })"));
+}
+
+TEST_CASE("sync.conflict.strategy with an unsupported value throws", "[migration][sync]") {
+  CHECK_THROWS_AS(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } },
+    "sync": { "enabled": true, "conflict": { "strategy": "yoloWins" } }
+  })"), std::runtime_error);
 }
 
 TEST_CASE("a bare DELETE FROM with no WHERE on a schema without sync still notifies subscribers (#63)", "[migration][notify]") {

--- a/cpp/tests/sync/SyncContractTests.cpp
+++ b/cpp/tests/sync/SyncContractTests.cpp
@@ -14,8 +14,22 @@ TEST_CASE("fromDefinition parses basePath/sinceParam/limitParam and pagination d
   REQUIRE(contract.endpoint.basePath == "/customers");
   REQUIRE(contract.endpoint.sinceParam == "updatedAfter");
   REQUIRE(contract.endpoint.limitParam == "limit");
+  REQUIRE(contract.endpoint.cursorField == "updatedAt");
   REQUIRE(contract.pageSize == 20);
   REQUIRE(contract.maxPagesPerSession == 20);
+}
+
+TEST_CASE("fromDefinition honors a custom endpoint.cursorField, independent of conflict strategy", "[sync][SyncContract]") {
+  auto serverWins = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit", "cursorField": "modifiedAt" },
+    "conflict": { "strategy": "serverWins" }
+  })"));
+  REQUIRE(serverWins.endpoint.cursorField == "modifiedAt");
+
+  auto lastWriteWins = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit", "cursorField": "modifiedAt" }
+  })"));
+  REQUIRE(lastWriteWins.endpoint.cursorField == "modifiedAt");
 }
 
 TEST_CASE("fromDefinition honors explicit pagination values", "[sync][SyncContract]") {
@@ -68,4 +82,60 @@ TEST_CASE("fromDefinition rejects a negative maxPagesPerSession", "[sync][SyncCo
 
 TEST_CASE("an old-format schema (method/path) produces a clear error, not a silent default", "[sync][SyncContract]") {
   REQUIRE_THROWS_WITH(SyncContract::fromDefinition(json::parse(R"({"endpoint": { "method": "POST", "path": "/sync/customers" }})")), Equals("SyncContract: sync.endpoint.basePath is required"));
+}
+
+TEST_CASE("fromDefinition defaults conflict to lastWriteWins/updatedAt when absent", "[sync][SyncContract]") {
+  auto contract = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" }
+  })"));
+
+  REQUIRE(contract.conflict.strategy == "lastWriteWins");
+  REQUIRE(contract.conflict.field == "updatedAt");
+}
+
+TEST_CASE("fromDefinition honors an explicit conflict strategy and custom field", "[sync][SyncContract]") {
+  auto contract = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+    "conflict": { "strategy": "lastWriteWins", "field": "modifiedAt" }
+  })"));
+
+  REQUIRE(contract.conflict.strategy == "lastWriteWins");
+  REQUIRE(contract.conflict.field == "modifiedAt");
+}
+
+TEST_CASE("fromDefinition honors serverWins/clientWins strategies", "[sync][SyncContract]") {
+  auto server = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+    "conflict": { "strategy": "serverWins" }
+  })"));
+  REQUIRE(server.conflict.strategy == "serverWins");
+
+  auto client = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+    "conflict": { "strategy": "clientWins" }
+  })"));
+  REQUIRE(client.conflict.strategy == "clientWins");
+}
+
+TEST_CASE("fromDefinition rejects an unsupported conflict strategy", "[sync][SyncContract]") {
+  REQUIRE_THROWS_WITH(
+    SyncContract::fromDefinition(json::parse(R"({
+      "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+      "conflict": { "strategy": "yoloWins" }
+    })")),
+    Equals("SyncContract: sync.conflict.strategy 'yoloWins' is not supported")
+  );
+}
+
+// A `_salve_sync_definitions` row persisted by a version of the library predating this struct
+// stored `conflict` as a plain string (e.g. "lastWriteWins"), not an object — a cold-start reopen
+// on stale persisted config must fall back to defaults instead of throwing.
+TEST_CASE("fromDefinition falls back to defaults when conflict is a legacy plain string", "[sync][SyncContract]") {
+  auto contract = SyncContract::fromDefinition(json::parse(R"({
+    "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+    "conflict": "lastWriteWins"
+  })"));
+
+  REQUIRE(contract.conflict.strategy == "lastWriteWins");
+  REQUIRE(contract.conflict.field == "updatedAt");
 }

--- a/cpp/tests/sync/SyncOperationApplierTests.cpp
+++ b/cpp/tests/sync/SyncOperationApplierTests.cpp
@@ -531,3 +531,43 @@ TEST_CASE("apply with clientWins still inserts a row that doesn't exist locally"
   REQUIRE(stats.inserted == 1);
   REQUIRE(nameOf(*conn, "1") == "server-name");
 }
+
+TEST_CASE("rewriteLocalRow under clientWins with no comparable field never overwrites a concurrent local edit", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_client_wins_no_field_replace", "clientWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('temp-1', 'alice')", {});
+  SyncOperationApplier applier(conn, SyncConflict{"clientWins", "updatedAt"});
+
+  // Response reflects the state of the row when the POST was sent.
+  auto response = json::parse(R"({ "id": "srv-1", "name": "alice" })");
+
+  // A local edit lands after the request body was built but before the
+  // response is applied — with no "updatedAt" column to compare against, the
+  // old (pre-fix) behavior applied the stale response unconditionally,
+  // silently discarding this edit even under clientWins.
+  conn->execute("UPDATE customers SET name = 'alice-v2' WHERE id = 'temp-1'", {});
+
+  SyncApplyGuard(conn).applyWithBypass([&] {
+    applyReplace(applier, "customers", "temp-1", response);
+  });
+
+  // PK rewrite (identity) still applies — only the data columns are protected.
+  REQUIRE_FALSE(nameOf(*conn, "temp-1").has_value());
+  REQUIRE(nameOf(*conn, "srv-1") == "alice-v2");
+}
+
+TEST_CASE("rewriteLocalRow under serverWins with no comparable field also skips the stale data merge", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_server_wins_no_field_replace", "serverWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('temp-1', 'alice')", {});
+  SyncOperationApplier applier(conn, SyncConflict{"serverWins", "updatedAt"});
+
+  auto response = json::parse(R"({ "id": "srv-1", "name": "alice" })");
+  conn->execute("UPDATE customers SET name = 'alice-v2' WHERE id = 'temp-1'", {});
+
+  SyncApplyGuard(conn).applyWithBypass([&] {
+    applyReplace(applier, "customers", "temp-1", response);
+  });
+
+  // Deferred to the next pull session (which always overwrites under
+  // serverWins) rather than risking a stale mid-flight echo here.
+  REQUIRE(nameOf(*conn, "srv-1") == "alice-v2");
+}

--- a/cpp/tests/sync/SyncOperationApplierTests.cpp
+++ b/cpp/tests/sync/SyncOperationApplierTests.cpp
@@ -30,6 +30,18 @@ std::shared_ptr<SQLiteConnection> openWithCustomers(const std::string& testName)
   return conn;
 }
 
+// serverWins/clientWins require no timestamp column at all.
+std::shared_ptr<SQLiteConnection> openWithCustomersNoTimestamp(const std::string& testName, const std::string& strategy) {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath(testName));
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "name": { "type": "text" } },
+    "sync": { "enabled": true, "conflict": { "strategy": ")" + strategy + R"(" } }
+  })"));
+  return conn;
+}
+
 std::optional<std::string> nameOf(SQLiteConnection& conn, const std::string& id) {
   auto rows = conn.execute("SELECT name FROM customers WHERE id = ?", { id });
   if (rows.rows.empty()) return std::nullopt;
@@ -438,4 +450,84 @@ TEST_CASE("a real edit after replace updates the same frozen localId row instead
   auto meta = conn->execute("SELECT localId, status FROM _salve_sync_metadata WHERE tableName = 'customers'", {});
   REQUIRE(std::get<std::string>(meta.rows[0][0]) == "temp-1");
   REQUIRE(std::get<std::string>(meta.rows[0][1]) == "PENDING");
+}
+
+TEST_CASE("apply with a custom lastWriteWins field compares that column, not 'updatedAt'", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = std::make_shared<SQLiteConnection>(uniqueDbPath("applier_custom_field"));
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "name": { "type": "text" }, "modifiedAt": { "type": "datetime", "nullable": false } },
+    "sync": { "enabled": true, "conflict": { "strategy": "lastWriteWins", "field": "modifiedAt" } }
+  })"));
+  conn->execute("INSERT INTO customers (id, name, modifiedAt) VALUES ('1', 'old-name', 100)", {});
+  SyncOperationApplier applier(conn, SyncConflict{"lastWriteWins", "modifiedAt"});
+
+  // Newer remote wins.
+  auto newer = json::parse(R"([{ "id": "1", "name": "new-name", "modifiedAt": 200 }])").asArray();
+  applier.apply("customers", newer);
+  REQUIRE(nameOf(*conn, "1") == "new-name");
+
+  // Stale remote is skipped.
+  auto stale = json::parse(R"([{ "id": "1", "name": "stale-name", "modifiedAt": 150 }])").asArray();
+  applier.apply("customers", stale);
+  REQUIRE(nameOf(*conn, "1") == "new-name");
+}
+
+TEST_CASE("apply with serverWins always overwrites, even when the remote has no newer timestamp", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_server_wins_update", "serverWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('1', 'local-name')", {});
+  SyncOperationApplier applier(conn, SyncConflict{"serverWins", "updatedAt"});
+
+  auto rows = json::parse(R"([{ "id": "1", "name": "server-name" }])").asArray();
+  auto stats = applier.apply("customers", rows);
+
+  REQUIRE(stats.updated == 1);
+  REQUIRE(nameOf(*conn, "1") == "server-name");
+}
+
+TEST_CASE("apply with serverWins always applies a tombstone for an existing row", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_server_wins_delete", "serverWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('1', 'local-name')", {});
+  SyncOperationApplier applier(conn, SyncConflict{"serverWins", "updatedAt"});
+
+  auto rows = json::parse(R"([{ "id": "1", "deletedAt": 100 }])").asArray();
+  auto stats = applier.apply("customers", rows);
+
+  REQUIRE(stats.deleted == 1);
+}
+
+TEST_CASE("apply with clientWins never overwrites an existing local row", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_client_wins_update", "clientWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('1', 'local-name')", {});
+  SyncOperationApplier applier(conn, SyncConflict{"clientWins", "updatedAt"});
+
+  auto rows = json::parse(R"([{ "id": "1", "name": "server-name" }])").asArray();
+  auto stats = applier.apply("customers", rows);
+
+  REQUIRE(stats.updated == 0);
+  REQUIRE(nameOf(*conn, "1") == "local-name");
+}
+
+TEST_CASE("apply with clientWins never applies a tombstone for an existing local row", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_client_wins_delete", "clientWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('1', 'local-name')", {});
+  SyncOperationApplier applier(conn, SyncConflict{"clientWins", "updatedAt"});
+
+  auto rows = json::parse(R"([{ "id": "1", "deletedAt": 100 }])").asArray();
+  auto stats = applier.apply("customers", rows);
+
+  REQUIRE(stats.deleted == 0);
+  REQUIRE_FALSE(deletedAtOf(*conn, "1").has_value());
+}
+
+TEST_CASE("apply with clientWins still inserts a row that doesn't exist locally", "[sync][SyncOperationApplier][conflict]") {
+  auto conn = openWithCustomersNoTimestamp("applier_client_wins_insert", "clientWins");
+  SyncOperationApplier applier(conn, SyncConflict{"clientWins", "updatedAt"});
+
+  auto rows = json::parse(R"([{ "id": "1", "name": "server-name" }])").asArray();
+  auto stats = applier.apply("customers", rows);
+
+  REQUIRE(stats.inserted == 1);
+  REQUIRE(nameOf(*conn, "1") == "server-name");
 }

--- a/cpp/tests/sync/SyncOrchestratorTests.cpp
+++ b/cpp/tests/sync/SyncOrchestratorTests.cpp
@@ -313,7 +313,7 @@ TEST_CASE("a pulled page's last row without a numeric updatedAt/deletedAt fails 
 
   REQUIRE_THROWS_WITH(
     SyncOrchestrator().triggerSync("customers", /*discardIfBusy*/ false),
-    ContainsSubstring("no numeric updatedAt or deletedAt")
+    ContainsSubstring("no numeric 'updatedAt' or deletedAt")
   );
 
   SyncCursorStore cursorStore(conn);
@@ -955,4 +955,104 @@ TEST_CASE("a pre-#84 opaque cursor is reset on registration; the first pull star
   SyncOrchestrator().triggerSync("customers", /*discardIfBusy*/ false);
 
   REQUIRE(captured.url.find("updatedAfter=0") != std::string::npos);
+}
+
+// ── Conflict strategies: serverWins/clientWins through a full session ───────
+
+// No local timestamp column — serverWins/clientWins don't require one. The
+// API payload still carries "updatedAt" for pull cursor advancement, which
+// is orthogonal to the conflict strategy (see plan discussion in #103-adjacent work).
+std::shared_ptr<SQLiteConnection> openOrchestratorFixtureNoTimestamp(const std::string& testName, const std::string& strategy) {
+  resetSecureStore();
+
+  DatabaseManager::shared().open(uniqueDbName(testName));
+  MigrationEngine engine(DatabaseManager::shared().connection());
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "name": { "type": "text" } },
+    "sync": {
+      "enabled": true,
+      "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+      "conflict": { "strategy": ")" + strategy + R"(" }
+    }
+  })"));
+
+  DatabaseManager::shared().configureCredentials(
+    "oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken",
+    InitialCredentialTokens{"access-1", "refresh-1"}
+  );
+  DatabaseManager::shared().configureNetwork("https://api.company.com", 5000.0);
+
+  return DatabaseManager::shared().connection();
+}
+
+TEST_CASE("triggerSync with serverWins overwrites a local row and advances the cursor via the JSI bridge", "[sync][SyncOrchestrator][conflict]") {
+  auto conn = openOrchestratorFixtureNoTimestamp("orchestrator_server_wins", "serverWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('1', 'local-name')", {});
+
+  respondByRoute(
+    [](const HttpRequest&) -> HttpOutcome { return HttpResponse{200, {}, R"([{"id":"1","name":"server-name","updatedAt":500}])"}; },
+    nullptr, nullptr, nullptr
+  );
+
+  auto result = SyncOrchestrator().triggerSync("customers", /*discardIfBusy*/ false);
+
+  // `result->updated` also folds in push's own replace of the freshly-inserted
+  // local row (auto-queued by the insert trigger) — assert on the row state
+  // directly instead, mirroring the existing tombstone test's pattern.
+  REQUIRE(result.has_value());
+  REQUIRE(result->cursor.value() == "499");
+
+  auto row = conn->execute("SELECT name FROM customers WHERE id = '1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "server-name");
+}
+
+TEST_CASE("triggerSync with clientWins keeps the local row and still advances the cursor via the JSI bridge", "[sync][SyncOrchestrator][conflict]") {
+  auto conn = openOrchestratorFixtureNoTimestamp("orchestrator_client_wins", "clientWins");
+  conn->execute("INSERT INTO customers (id, name) VALUES ('1', 'local-name')", {});
+
+  respondByRoute(
+    [](const HttpRequest&) -> HttpOutcome { return HttpResponse{200, {}, R"([{"id":"1","name":"server-name","updatedAt":500}])"}; },
+    nullptr, nullptr, nullptr
+  );
+
+  auto result = SyncOrchestrator().triggerSync("customers", /*discardIfBusy*/ false);
+
+  REQUIRE(result.has_value());
+  REQUIRE(result->cursor.value() == "499"); // cursor still advances — orthogonal to the strategy
+
+  auto row = conn->execute("SELECT name FROM customers WHERE id = '1'", {});
+  REQUIRE(std::get<std::string>(row.rows[0][0]) == "local-name");
+}
+
+TEST_CASE("triggerSync advances the cursor from endpoint.cursorField, independent of the conflict strategy", "[sync][SyncOrchestrator][conflict]") {
+  resetSecureStore();
+  DatabaseManager::shared().open(uniqueDbName("orchestrator_custom_cursor_field"));
+  MigrationEngine engine(DatabaseManager::shared().connection());
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "name": { "type": "text" } },
+    "sync": {
+      "enabled": true,
+      "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit", "cursorField": "modifiedAt" },
+      "conflict": { "strategy": "serverWins" }
+    }
+  })"));
+  DatabaseManager::shared().configureCredentials(
+    "oauth2", "Authorization", "Bearer", "/auth/refresh", "$.accessToken", "$.refreshToken",
+    InitialCredentialTokens{"access-1", "refresh-1"}
+  );
+  DatabaseManager::shared().configureNetwork("https://api.company.com", 5000.0);
+
+  respondByRoute(
+    // "updatedAt" is absent — only "modifiedAt" is present. A hardcoded cursor
+    // field would fail to advance the cursor at all here.
+    [](const HttpRequest&) -> HttpOutcome { return HttpResponse{200, {}, R"([{"id":"1","name":"a","modifiedAt":500}])"}; },
+    nullptr, nullptr, nullptr
+  );
+
+  auto result = SyncOrchestrator().triggerSync("customers", /*discardIfBusy*/ false);
+
+  REQUIRE(result.has_value());
+  REQUIRE(result->cursor.value() == "499");
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1939,7 +1939,7 @@ PODS:
     - React-utils (= 0.86.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.86.0)
-  - SalveDb (0.1.0):
+  - SalveDb (0.1.1):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -2210,85 +2210,85 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: 5b7b20f65223b972a6bc9da80a4c495ee1de1551
-  NitroModules: b4174dd303728e16ad1afb79f64c1a5c69a3b373
-  NitroSalvetron: fa66b08a82c365d2fcc4bced8ca93f7be3b5ebf6
+  hermes-engine: 0fb5ec952cfb594172193ca940a6860a3d06a24f
+  NitroModules: 7e004af1d2cbc3072b071de62aeb9c147ef79d34
+  NitroSalvetron: 2be94fad374d438d5bce891683f12b0c4b0057ae
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
-  RCTSwiftUIWrapper: ab2ca548be15d63afa95103afc8685a7c3eab78b
+  RCTSwiftUIWrapper: 1feaf484029fd6294fe8bc401d28e1d803eca142
   RCTTypeSafety: 3eaed17dbddb0b989208b062ea14c44d412b9780
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
-  React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
-  React-Core-prebuilt: 13924a267683b3d6fa4bde9c80380becf83a9c5c
-  React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
-  React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
+  React-Core: b0a0038e05720fb8148759404e9c354e3e60043c
+  React-Core-prebuilt: 7da85c26e5616d52f119b81ce5e3e6fc5c9bda49
+  React-CoreModules: a1121b3182200be11e078940159c67ff95ee98b4
+  React-cxxreact: 8f74977959064bee99af63bb0ad95b6c3dbec921
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
-  React-defaultsnativemodule: 603c108411d39d7bb5ccb8c270f1f50cb6207e10
-  React-domnativemodule: c49a502edc85f515a029c341fe5fba155fa6675c
-  React-Fabric: acc4915d719db793c5853e5c74b54ea5aa48e865
-  React-FabricComponents: aebebc98914a4a8fc962fa7b5b98ebaf250acb68
-  React-FabricImage: 42e99e48ff73c8b20cee229e622977d0b97b6247
-  React-featureflags: c6d8d8d52acf3a956485726076b73eeff7935340
-  React-featureflagsnativemodule: c992de92dcf30dcf09efdec17752abe4128ec55f
-  React-graphics: 239fd9b0512e539d3563f0825618f4e49795eefd
-  React-hermes: ae4685ca9fa5f47003bc594d3f146e29284136d1
-  React-idlecallbacksnativemodule: 10a5be842ab181953c772a3f28cdf94572833eb0
-  React-ImageManager: c36a56c3b13eba92e1d0d30da35d0a1ccf29cd6c
-  React-intersectionobservernativemodule: 71404bfa47d31e4143cc9db3e26178b5cfcd07e1
-  React-jserrorhandler: ca2eeb03c1a77bbfab1b5425b943e3e8d92295f2
-  React-jsi: c4b6daf8a31ac54f2db49cd6cce29720fec1f3a8
-  React-jsiexecutor: acdc1a217b7ea29bcf6315b770d01e6b1c2fca14
-  React-jsinspector: 95d6394efe9fb4a64ed33afc076b32a6384c8514
-  React-jsinspectorcdp: 6ce51378a552feaaaac1a7b0d995fa0c49fa4f8c
-  React-jsinspectornetwork: 0db435c9264f200635fdf294a3b643dd3946d4cf
-  React-jsinspectortracing: 2e4470e1f301ff597bd65299aa95da4bae6e5c4f
-  React-jsitooling: 796bc991cdce68e2cc059d0271a28e0d4f8b0891
-  React-jsitracing: f3008e7b5e1d9de8d9f2ca1b85824ed86b0cea00
-  React-logger: fff73f4ceecad968c97baafdc77dcf84befc38b6
-  React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
-  React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
-  React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
-  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
-  React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
-  React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
+  React-defaultsnativemodule: 7c8182addbb79ec576c589186b51e3fb405da7da
+  React-domnativemodule: 576bd1e6ad81477997dcb556e6db1f005134356b
+  React-Fabric: 4cbd22315ddb9e33441437f851117d314d1b4ad3
+  React-FabricComponents: efe374aecaf1bbc2fb9a195ece4b50fd9f66bfa0
+  React-FabricImage: cfeffc0b527de8bc2dc5a50618dad119361d0ec3
+  React-featureflags: 98931b22f5f4b861a3985b75bd79c5fcbe4618ab
+  React-featureflagsnativemodule: 518c2e279cdb3835604f7e8fb15f4c2691336b4c
+  React-graphics: ac9ff09da733d98c0e5eddb589dc7f9f082c9531
+  React-hermes: bd1a14a982e63ee75e9c9cb8d11d3d4b5f330196
+  React-idlecallbacksnativemodule: b6378d3bca83d8284e1abaa51251ee1ce570d85a
+  React-ImageManager: 4936349da191d1bc29ed2bbaf5a2dd74bfdf5ed8
+  React-intersectionobservernativemodule: d9a6451f2aa1f1c989d5d5e0d967db2c07d0c48c
+  React-jserrorhandler: 2455567e21fcc036f96015b2b8eb4eb13e0d8d05
+  React-jsi: bf5ec8e7a7b26bddc39ab7f821af5aad8bb94a33
+  React-jsiexecutor: cf6c957f578dd491ec8ae516a39aff2cf7369f1a
+  React-jsinspector: 63e9b9f9a5b6c51bf38deea2b379a63754c0ab0d
+  React-jsinspectorcdp: 327082854cdebb1f500a669c51146b9fd871058c
+  React-jsinspectornetwork: bbc5c2e881252075d63dc679f18cd856c2def94e
+  React-jsinspectortracing: ea6ec857ead0de4e6bbb2e12ee48ae4381938874
+  React-jsitooling: 52e278666b35e856414d613d7dc50d1f0d50d9a5
+  React-jsitracing: 642172314677a1d1780b81f4e2e4a3f4d3ccf238
+  React-logger: 35cda3ab8977c6c4546e3cf6dc8f91bacec25934
+  React-Mapbuffer: c058c051f571589e37a29bce18d0e9b730faa9d0
+  React-microtasksnativemodule: 03752e60738a797bb49f4d6cb0291dfa398099b8
+  React-mutationobservernativemodule: 2e568e13c98bd185fe83266795233fa7ad2cbc19
+  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
+  React-NativeModulesApple: a4713821c9caae40ae33eef933a6e692a6f4a81d
+  React-networking: b344a1a41a4729ef859123b7a234f3092761cb25
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
-  React-perflogger: 865984e492514aa6e5279fc3e663132cfa4d5022
-  React-performancecdpmetrics: 2efbf9bdb48c8d8446f4dd10e8bf0dc5d711772f
-  React-performancetimeline: 9d256484bff1513481be9f234baba694dc3b52e2
+  React-perflogger: a0d581c6cc174e847877107ddac3f4fc9b518dc7
+  React-performancecdpmetrics: 91d3d0dce2e3a239ea68cc2882e75b11a61cbf2e
+  React-performancetimeline: 4b9e04002c1ddba95167276a86424e5face65605
   React-RCTActionSheet: 902c79deec52f99cc48b1051b59bcbe86787d339
-  React-RCTAnimation: 09cf722039ae30ff5d64e2b011ff054ae651c3b6
-  React-RCTAppDelegate: a47de6fddb7eb0c028abba83138a5ce283bd7e77
-  React-RCTBlob: 38c418d067e0c61818223503063310122e44c588
-  React-RCTFabric: 480ca2a105730e1790cfd13291d086cb53725825
-  React-RCTFBReactNativeSpec: 63131378510a5191515a4adfc308e65b465106f4
-  React-RCTImage: 3ce36f82441b76b715818ee7ee95f6f5b34f9ee1
-  React-RCTLinking: 2f7b5ed4983122e5115732d25a4360960eab583c
-  React-RCTNetwork: dcd3b180f33da86f5dc5e928a816eb5464fa7f16
-  React-RCTRuntime: 6ef8e778fbab426b12eb5a9b5f7a0e86313c5a10
-  React-RCTSettings: b97727ec8c55c35bd284457a647c938c040b942b
-  React-RCTText: 4d1b88f6d3e1a43afe46706d956ec6664c87b984
-  React-RCTVibration: 415d14d6a1a64bf947fcef6b193915a494431168
+  React-RCTAnimation: f50eac1c9dbea36c4abc69cb24e2da4364374055
+  React-RCTAppDelegate: a5d746fec869d15a8f6eecce60510c18e52135d5
+  React-RCTBlob: e544dc72edc6f277c67e85493b0a405e1993c250
+  React-RCTFabric: 8003ea99830c294857d41469a888b033e5ad91a6
+  React-RCTFBReactNativeSpec: 8a3506041284fdc75da90e6fa40fb9b575414a39
+  React-RCTImage: fb85496986a53d9e11a835124a083b7c7c33f898
+  React-RCTLinking: b8eafcdedaebf981a18396db61d1190f5279ea81
+  React-RCTNetwork: 03573c4fcc73e28f48fea7aea69310b6955a749c
+  React-RCTRuntime: 08d58920b217b2d7715d5da595794e63520cd2d9
+  React-RCTSettings: f9b278b46e5de1ff8b843bb7aefaee721f06572d
+  React-RCTText: 7266943febf3382dac8adce9ba0de95b90c26e9e
+  React-RCTVibration: 27e1952701ec858922062f25a59b0c48e7153151
   React-rendererconsistency: ef8519bdd9931261c6561bfad6506356b8108387
-  React-renderercss: 1aa1bf99fa2ace143eb87d5190fd43609fc1e832
-  React-rendererdebug: 40a4fb3dea21a7ac1759ca0eb6c88a924aecb075
-  React-RuntimeApple: 84fadbb4fe8ca531e15e29a22af05911f17569c6
-  React-RuntimeCore: f4d9af5f16d37e63308cb03b36c89d01e7f68a06
-  React-runtimeexecutor: 4d59410f66af529d04c84c8b152ced07dabc471e
-  React-RuntimeHermes: fd719d8f4d9ce79636fe2e09e94b0ac31b7b263b
-  React-runtimescheduler: 784033620aa5515e2f45a60369eed4d32f9400b8
-  React-timing: a16df9ae98f950396d9ce3abf43cb0cb2f21194c
-  React-utils: b68ee619aef28d8f9b85532d98db0327f7bdf743
-  React-viewtransitionnativemodule: 11fe091101d381451b1542c37b2745900254f096
-  React-webperformancenativemodule: b5d249419f1546663845c82f24de4e18a3180997
-  ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
-  ReactCodegen: 1973e629fe2614a7b2cf72919cb9935b6c34675f
-  ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
+  React-renderercss: edc1b0a18b12d681f8edbc779039dc6db32cf7b2
+  React-rendererdebug: 074ec3420f3bab2bea498da65e5a17e9288c90d0
+  React-RuntimeApple: 180682587e82ae4fc525f7d6636ed5db39c1e78c
+  React-RuntimeCore: 991cdb27072f7885750fdad4a70c2b919533e4ef
+  React-runtimeexecutor: bfec6ca5e62c6b2460a4adf0fddce0c4db0a8748
+  React-RuntimeHermes: dcb07afe0f38c1cbaf48b7a1bf4904e867529726
+  React-runtimescheduler: fdf0b71e519e416ad38c76525df43eba8dd78db2
+  React-timing: 7b538f379678210bf30d8541eb4cf007c000c6f3
+  React-utils: a15da1da76aee3dd0ed9f51d62bf1c09be17c221
+  React-viewtransitionnativemodule: 8556c844dcd691ab3fe1b32bbf8f58c8c9a49c75
+  React-webperformancenativemodule: 4d1d0258107fe0cb8ef5c9ac17a6a099785f2995
+  ReactAppDependencyProvider: adf5403892170fbe996fce485a703f25df08db66
+  ReactCodegen: db8e2836b82f6f4c3ef1463cb6f6cd61a25b8cc8
+  ReactCommon: 4d01bfb533b93a2103329dfefc74db6a9e272888
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  SalveDb: 7fde6f8d088bee4aeddde27375fa2c02f7cfbc8c
+  SalveDb: 7cda9bfbcf48e41c1a51a57da851c28d7d228bf0
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: e1823b20150f420cb2568adef65d05a5d5c7241b
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/src/__harness__/SalveDb.core.harness.ts
+++ b/example/src/__harness__/SalveDb.core.harness.ts
@@ -278,7 +278,7 @@ describe('sync_queue side effects from real writes', () => {
       sync: {
         enabled: true,
         direction: 'bidirectional',
-        conflict: 'lastWriteWins',
+        conflict: { strategy: 'lastWriteWins' },
         transport: 'rest',
         endpoint: { basePath: '/customers', sinceParam: 'updatedAfter', limitParam: 'limit' },
         pagination: { pageSize: 20, maxPagesPerSession: 20 },

--- a/example/src/schemas/ProductSchema.ts
+++ b/example/src/schemas/ProductSchema.ts
@@ -26,7 +26,7 @@ export const ProductSchema = {
   sync: {
     enabled: true,
     direction: 'bidirectional',
-    conflict: 'lastWriteWins',
+    conflict: { strategy: 'lastWriteWins' },
     transport: 'rest',
     endpoint: { basePath: '/products', sinceParam: 'modified_since', limitParam: 'page_size' },
     pagination: { pageSize: 25, maxPagesPerSession: 20 },

--- a/example/src/schemas/UserSchema.ts
+++ b/example/src/schemas/UserSchema.ts
@@ -26,7 +26,7 @@ export const UserSchema = {
   sync: {
     enabled: true,
     direction: 'bidirectional',
-    conflict: 'lastWriteWins',
+    conflict: { strategy: 'lastWriteWins' },
     transport: 'rest',
     endpoint: { basePath: '/users', sinceParam: 'updatedAfter', limitParam: 'limit' },
     pagination: { pageSize: 50, maxPagesPerSession: 20 },

--- a/src/database/classes/QueryDb/__tests__/QueryDb.writeSync.test.ts
+++ b/src/database/classes/QueryDb/__tests__/QueryDb.writeSync.test.ts
@@ -50,7 +50,9 @@ function makeSyncSchema(name: string): AnySchema {
     sync: {
       enabled: true,
       direction: 'bidirectional',
-      conflict: { strategy: 'lastWriteWins' },
+      // serverWins — this file tests write-triggered dispatch, not conflict
+      // resolution, so it needs no NOT NULL datetime column on the schema.
+      conflict: { strategy: 'serverWins' },
       transport: 'rest',
       endpoint: { basePath: `/${name}`, sinceParam: 'updatedAfter', limitParam: 'limit' },
     },

--- a/src/database/classes/QueryDb/__tests__/QueryDb.writeSync.test.ts
+++ b/src/database/classes/QueryDb/__tests__/QueryDb.writeSync.test.ts
@@ -50,7 +50,7 @@ function makeSyncSchema(name: string): AnySchema {
     sync: {
       enabled: true,
       direction: 'bidirectional',
-      conflict: 'lastWriteWins',
+      conflict: { strategy: 'lastWriteWins' },
       transport: 'rest',
       endpoint: { basePath: `/${name}`, sinceParam: 'updatedAfter', limitParam: 'limit' },
     },

--- a/src/database/classes/QueryDb/classes/DeleteQueryBuilder/__tests__/DeleteQueryBuilder.test.ts
+++ b/src/database/classes/QueryDb/classes/DeleteQueryBuilder/__tests__/DeleteQueryBuilder.test.ts
@@ -27,7 +27,7 @@ const syncEnabledSchema: AnySchema = {
   sync: {
     enabled: true,
     direction: 'bidirectional',
-    conflict: 'lastWriteWins',
+    conflict: { strategy: 'lastWriteWins' },
     transport: 'rest',
     endpoint: { basePath: '/orders', sinceParam: 'updatedAfter', limitParam: 'limit' },
   },

--- a/src/database/classes/QueryDb/classes/InsertQueryBuilder/__tests__/InsertQueryBuilder.test.ts
+++ b/src/database/classes/QueryDb/classes/InsertQueryBuilder/__tests__/InsertQueryBuilder.test.ts
@@ -22,7 +22,7 @@ const syncEnabledSchema: AnySchema = {
   sync: {
     enabled: true,
     direction: 'bidirectional',
-    conflict: 'lastWriteWins',
+    conflict: { strategy: 'lastWriteWins' },
     transport: 'rest',
     endpoint: { basePath: '/orders', sinceParam: 'updatedAfter', limitParam: 'limit' },
   },

--- a/src/database/classes/QueryDb/classes/UpdateQueryBuilder/__tests__/UpdateQueryBuilder.test.ts
+++ b/src/database/classes/QueryDb/classes/UpdateQueryBuilder/__tests__/UpdateQueryBuilder.test.ts
@@ -27,7 +27,7 @@ const syncEnabledSchema: AnySchema = {
   sync: {
     enabled: true,
     direction: 'bidirectional',
-    conflict: 'lastWriteWins',
+    conflict: { strategy: 'lastWriteWins' },
     transport: 'rest',
     endpoint: { basePath: '/orders', sinceParam: 'updatedAfter', limitParam: 'limit' },
   },

--- a/src/hooks/useQuery/__tests__/useQuery.readSync.test.tsx
+++ b/src/hooks/useQuery/__tests__/useQuery.readSync.test.tsx
@@ -42,7 +42,7 @@ function makeSyncSchema(name: string, enabled: boolean): AnySchema {
     sync: {
       enabled,
       direction: 'bidirectional',
-      conflict: 'lastWriteWins',
+      conflict: { strategy: 'lastWriteWins' },
       transport: 'rest',
       endpoint: { basePath: `/${name}`, sinceParam: 'updatedAfter', limitParam: 'limit' },
     },

--- a/src/hooks/useQuery/__tests__/useQuery.readSync.test.tsx
+++ b/src/hooks/useQuery/__tests__/useQuery.readSync.test.tsx
@@ -42,7 +42,9 @@ function makeSyncSchema(name: string, enabled: boolean): AnySchema {
     sync: {
       enabled,
       direction: 'bidirectional',
-      conflict: { strategy: 'lastWriteWins' },
+      // serverWins — this file tests read-triggered dispatch, not conflict
+      // resolution, so it needs no NOT NULL datetime column on the schema.
+      conflict: { strategy: 'serverWins' },
       transport: 'rest',
       endpoint: { basePath: `/${name}`, sinceParam: 'updatedAfter', limitParam: 'limit' },
     },

--- a/src/types/sync/ConflictStrategy.ts
+++ b/src/types/sync/ConflictStrategy.ts
@@ -4,5 +4,4 @@
 export type ConflictStrategy =
   | "lastWriteWins"
   | "serverWins"
-  | "clientWins"
-  | "manual";
+  | "clientWins";

--- a/src/types/sync/IEndpointDefinition.ts
+++ b/src/types/sync/IEndpointDefinition.ts
@@ -17,6 +17,15 @@ export interface IEndpointDefinition {
   /** Query-param name carrying the page size, e.g. `"limit"`. */
   limitParam: string;
 
+  /**
+   * Field name (in each pulled row's JSON) carrying that row's timestamp —
+   * read from the last row of a page to advance the incremental-pull
+   * cursor. Required regardless of `sync.conflict.strategy`: pagination
+   * needs it independent of how conflicts get resolved.
+   * @default "updatedAt"
+   */
+  cursorField?: string;
+
   /** Extra headers merged into every request for this entity. */
   headers?: Record<string, string>;
 }

--- a/src/types/sync/ISyncDefinition.ts
+++ b/src/types/sync/ISyncDefinition.ts
@@ -5,13 +5,61 @@ import type { IEndpointDefinition } from "./IEndpointDefinition";
 import type { IBackgroundDefinition } from "./IBackgroundDefinition";
 import type { IPaginationDefinition } from "./IPaginationDefinition";
 
+/**
+ * Conflict resolution config. (The incremental-pull cursor's timestamp field
+ * is a separate, always-required setting, independent of strategy:
+ * `endpoint.cursorField`.)
+ */
+export type ConflictConfig =
+  | {
+      strategy: Extract<ConflictStrategy, "lastWriteWins">;
+      /**
+       * Names the column — declared in the local schema (`columns[field]`)
+       * and present in the API payload — compared to resolve conflicts:
+       * whichever side has the newer value wins. Configurable so an API's
+       * own naming convention can be used instead of forcing `updatedAt`.
+       *
+       * Must reference a `columns` entry declared as `{ type: "datetime",
+       * nullable: false }` — `Database.register()` throws at registration
+       * time if it doesn't (a non-datetime or missing column can't be
+       * compared as a timestamp).
+       * @default "updatedAt"
+       */
+      field?: string;
+    }
+  | {
+      /** The server's pulled row always overwrites the local row, regardless of any local edit. */
+      strategy: Extract<ConflictStrategy, "serverWins">;
+    }
+  | {
+      /** An existing local row is never overwritten by a pulled server row; a row that doesn't exist locally yet still gets inserted. */
+      strategy: Extract<ConflictStrategy, "clientWins">;
+    };
+
 /** Sync contract */
 export interface ISyncDefinition {
+  /** Whether this schema participates in sync at all — gates every trigger (read, write, app-open, background). */
   enabled: boolean;
+
+  /** Direction of sync. MVP only supports `"bidirectional"`. */
   direction: SyncDirection;
-  conflict: ConflictStrategy;
+
+  /** How pull conflicts (server row vs. existing local row) get resolved. */
+  conflict: ConflictConfig;
+
+  /** Transport protocol. MVP only supports `"rest"`. */
   transport: Transport;
+
+  /** REST module contract for this entity: base path, query params, cursor field. */
   endpoint: IEndpointDefinition;
+
+  /**
+   * Intended to gate whether this schema participates in the background
+   * sync wake. Not yet consulted natively — `triggerSyncAll` currently runs
+   * every `sync.enabled` schema regardless of this flag.
+   */
   background?: IBackgroundDefinition;
+
+  /** Pull page size and per-session page cap. @default undefined (falls back to the engine's own defaults) */
   pagination?: IPaginationDefinition;
 }


### PR DESCRIPTION
## Summary

- `sync.conflict.strategy` was declared in the TS type but never read natively — actual pull-conflict behavior was hardcoded `lastWriteWins` comparing a fixed `updatedAt` column/field, on both the local schema and the API payload. Any API naming its timestamp field differently couldn't integrate without adapting to this library's convention.
- `sync.conflict` is now `{ strategy: "lastWriteWins", field?: string }` (default `"updatedAt"`) | `{ strategy: "serverWins" }` | `{ strategy: "clientWins" }`, all enforced natively in `SyncOperationApplier::apply()`. `manual` was dropped from the type until it's actually implemented.
- `MigrationEngine::registerSchema` only requires the `NOT NULL datetime` column for `lastWriteWins` (using the configured `field` name, not a hardcoded one); `serverWins`/`clientWins` require no timestamp column at all.
- The incremental-pull cursor's timestamp field moved to `sync.endpoint.cursorField` — it's needed for pagination regardless of conflict strategy, so it doesn't belong under `conflict`.

Closes #110

## Test plan

- [x] `npm run test:native` — 732 assertions / 285 test cases pass, including new coverage for a custom `lastWriteWins` field, `serverWins`/`clientWins` tombstone/insert/update paths, `cursorField` independent of strategy, and the missing-column error's default-vs-explicit hint — all through real `triggerSync` sessions via the JSI bridge, no mocks.
- [x] `npx jest` — 188 suites pass, including the migrated `conflict: { strategy: ... }` call sites.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run codegen` — no regression (conflict resolution is plain JSON inside `sync`, never a typed Nitro struct).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sync conflict strategies: `lastWriteWins`, `serverWins`, and `clientWins`.
  * Added support for selecting a custom conflict timestamp field.
  * Added configurable cursor fields for incremental sync pagination.
  * Preserved sensible defaults for existing sync configurations.

* **Bug Fixes**
  * Improved validation and error messages for invalid conflict settings.
  * Improved sync behavior for records without timestamp columns.

* **Tests**
  * Added coverage for conflict strategies, custom fields, cursor advancement, and tombstone handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->