### PR TITLE
feat: add Database.reset() to wipe local database and credentials

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(${PACKAGE_NAME} SHARED
 	../cpp/database/MigrationEngine.cpp
 		../cpp/database/SalveMetadataManager.cpp
 	../cpp/database/SchemaRegistry.cpp
+	../cpp/database/DatabaseResetter.cpp
 	../cpp/query/QueryExecutor.cpp
 	../cpp/sync/SyncOrchestrator.cpp
 	../cpp/sync/SyncNativeEntryPoint.cpp

--- a/cpp/HybridSalveDatabase.cpp
+++ b/cpp/HybridSalveDatabase.cpp
@@ -11,11 +11,13 @@
 namespace margelo::nitro::salvedb {
 
 HybridSalveDatabase::~HybridSalveDatabase() {
-  if (!DatabaseManager::shared().isOpen()) return;
-  auto conn = DatabaseManager::shared().connection();
-  for (int id : _ownedSubscriptionIds) {
-    try { conn->unsubscribe(id); } catch (...) {}
-  }
+  try {
+    if (!DatabaseManager::shared().isOpen()) return;
+    auto conn = DatabaseManager::shared().connection();
+    for (int id : _ownedSubscriptionIds) {
+      try { conn->unsubscribe(id); } catch (...) {}
+    }
+  } catch (...) {}
 }
 
 void HybridSalveDatabase::configure(const ConfigureParams& params) {

--- a/cpp/HybridSalveDatabase.cpp
+++ b/cpp/HybridSalveDatabase.cpp
@@ -1,12 +1,22 @@
 #include "HybridSalveDatabase.hpp"
 #include "database/DatabaseManager.hpp"
+#include "database/DatabaseResetter.hpp"
 #include "database/MigrationEngine.hpp"
 #include "database/NativeConfigStore.hpp"
 #include "platform/platform.hpp"
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
 namespace margelo::nitro::salvedb {
+
+HybridSalveDatabase::~HybridSalveDatabase() {
+  if (!DatabaseManager::shared().isOpen()) return;
+  auto conn = DatabaseManager::shared().connection();
+  for (int id : _ownedSubscriptionIds) {
+    try { conn->unsubscribe(id); } catch (...) {}
+  }
+}
 
 void HybridSalveDatabase::configure(const ConfigureParams& params) {
   if (params.name.empty())
@@ -90,6 +100,17 @@ std::shared_ptr<Promise<void>> HybridSalveDatabase::registerSchema(const std::st
   });
 }
 
+std::shared_ptr<Promise<void>> HybridSalveDatabase::reset() {
+  return Promise<void>::async([]() {
+    {
+      auto lock = DatabaseManager::shared().lockSync();
+      DatabaseResetter::reset();
+    }
+    // Outside the lock, like configure() — scheduleBackgroundSync() re-locks synchronously and would self-deadlock otherwise.
+    platform::scheduleBackgroundSync();
+  });
+}
+
 QueryResult HybridSalveDatabase::execute(
   const std::string& sql,
   const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params
@@ -125,11 +146,15 @@ double HybridSalveDatabase::subscribeToChanges(const std::function<void(const st
   int id = DatabaseManager::shared().connection()->subscribe(
     [callback](std::vector<std::string> tables) { callback(tables); }
   );
+  _ownedSubscriptionIds.push_back(id);
   return static_cast<double>(id);
 }
 
 void HybridSalveDatabase::unsubscribeFromChanges(double id) {
-  DatabaseManager::shared().connection()->unsubscribe(static_cast<int>(id));
+  int intId = static_cast<int>(id);
+  DatabaseManager::shared().connection()->unsubscribe(intId);
+  auto it = std::find(_ownedSubscriptionIds.begin(), _ownedSubscriptionIds.end(), intId);
+  if (it != _ownedSubscriptionIds.end()) _ownedSubscriptionIds.erase(it);
 }
 
 double HybridSalveDatabase::debugPreparedStatementCount() {

--- a/cpp/HybridSalveDatabase.hpp
+++ b/cpp/HybridSalveDatabase.hpp
@@ -3,6 +3,7 @@
 #include "HybridSalveDatabaseSpec.hpp"
 #include "query/QueryExecutor.hpp"
 #include "sync/SyncOrchestrator.hpp"
+#include <vector>
 
 namespace margelo::nitro::salvedb {
 
@@ -15,10 +16,12 @@ namespace margelo::nitro::salvedb {
 class HybridSalveDatabase: public HybridSalveDatabaseSpec {
 public:
   HybridSalveDatabase(): HybridObject(TAG) {}
+  ~HybridSalveDatabase() override;
 
 public:
   void configure(const ConfigureParams& params) override;
   std::shared_ptr<Promise<void>> registerSchema(const std::string& schemaJson) override;
+  std::shared_ptr<Promise<void>> reset() override;
   QueryResult execute(const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params) override;
   void beginTransaction() override;
   void commit() override;
@@ -32,6 +35,7 @@ public:
 private:
   QueryExecutor _queryExecutor;
   SyncOrchestrator _syncOrchestrator;
+  std::vector<int> _ownedSubscriptionIds;
 };
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/credentials/CredentialProvider.cpp
+++ b/cpp/credentials/CredentialProvider.cpp
@@ -38,6 +38,11 @@ void CredentialProvider::seedInitialTokens(const std::string& accessToken, const
   platform::setSecureValue(kRefreshTokenKey, refreshToken);
 }
 
+void CredentialProvider::clearStoredTokens() {
+  platform::deleteSecureValue(kAccessTokenKey);
+  platform::deleteSecureValue(kRefreshTokenKey);
+}
+
 std::optional<std::string> CredentialProvider::getAccessToken() const {
   return platform::getSecureValue(kAccessTokenKey);
 }

--- a/cpp/credentials/CredentialProvider.hpp
+++ b/cpp/credentials/CredentialProvider.hpp
@@ -38,6 +38,9 @@ public:
   // later app launch) — never overwrites a token natively refreshed since.
   void seedInitialTokens(const std::string& accessToken, const std::string& refreshToken);
 
+  // Deletes both stored tokens, so a later seedInitialTokens() isn't blocked by its already-seeded guard.
+  static void clearStoredTokens();
+
   // Current access token, or nullopt if none was ever seeded/refreshed.
   std::optional<std::string> getAccessToken() const;
 

--- a/cpp/database/DatabaseManager.cpp
+++ b/cpp/database/DatabaseManager.cpp
@@ -8,8 +8,15 @@ namespace margelo::nitro::salvedb {
 void DatabaseManager::open(const std::string& dbName, bool walMode) {
   std::string dir  = platform::getDocumentsDirectory();
   std::string path = dir + "/" + dbName + ".db";
+
+  if (_db && path == _dbPath && walMode == _dbWalMode) {
+    return; // same file already open — keep the connection (and its subscriptions) alive
+  }
+
   _db = std::make_shared<SQLiteConnection>(path, walMode);
-  // Keyed by schema name, not db file — avoid stale leaks across opens.
+  _dbPath = path;
+  _dbWalMode = walMode;
+  // Keyed by schema name, not db file — avoid stale leaks across a genuine file change.
   SchemaRegistry::shared().clear();
 }
 

--- a/cpp/database/DatabaseManager.hpp
+++ b/cpp/database/DatabaseManager.hpp
@@ -34,6 +34,7 @@ public:
     return instance;
   }
 
+  // Caller must hold lockSync().
   void open(const std::string& dbName, bool walMode = true);
 
   std::shared_ptr<SQLiteConnection> connection() const {
@@ -98,6 +99,12 @@ public:
   void closeForTesting() {
     auto lock = lockSync();
     _db.reset();
+    _dbPath.clear();
+    resetConfig();
+  }
+
+  // _dbPath/_dbWalMode intentionally untouched here — resetConfig() keeps `_db` alive, so the identity it describes is still accurate.
+  void resetConfig() {
     _credentials.reset();
     _network.reset();
     _background.reset();
@@ -108,6 +115,8 @@ public:
 private:
   DatabaseManager() = default;
   std::shared_ptr<SQLiteConnection> _db;
+  std::string _dbPath;
+  bool _dbWalMode = true;
   std::unique_ptr<CredentialProvider> _credentials;
   std::optional<NetworkConfig> _network;
   std::optional<BackgroundConfig> _background;

--- a/cpp/database/DatabaseResetter.cpp
+++ b/cpp/database/DatabaseResetter.cpp
@@ -86,7 +86,9 @@ void DatabaseResetter::reset() {
   auto& manager = DatabaseManager::shared();
 
   if (!manager.isOpen()) {
+    SchemaRegistry::shared().clear();
     CredentialProvider::clearStoredTokens();
+    manager.resetConfig();
     NativeConfigStore::remove();
     return;
   }

--- a/cpp/database/DatabaseResetter.cpp
+++ b/cpp/database/DatabaseResetter.cpp
@@ -1,0 +1,131 @@
+#include "DatabaseResetter.hpp"
+#include "DatabaseManager.hpp"
+#include "NativeConfigStore.hpp"
+#include "SchemaRegistry.hpp"
+#include "SQLiteConnection.hpp"
+#include "../credentials/CredentialProvider.hpp"
+#include "../sync/SyncApplyGuard.hpp"
+
+#include <array>
+#include <exception>
+
+namespace margelo::nitro::salvedb {
+
+namespace {
+
+class TransactionGuard {
+public:
+  explicit TransactionGuard(SQLiteConnection& conn) : _conn(conn) { _conn.beginTransaction(); }
+
+  TransactionGuard(const TransactionGuard&) = delete;
+  TransactionGuard& operator=(const TransactionGuard&) = delete;
+
+  ~TransactionGuard() {
+    if (!_committed) {
+      try { _conn.rollback(); } catch (...) {}
+    }
+  }
+
+  void commit() { _conn.commit(); _committed = true; }
+
+private:
+  SQLiteConnection& _conn;
+  bool _committed = false;
+};
+
+// _sync_apply_lock is excluded — SyncApplyGuard::applyWithBypass owns that row's lifecycle itself.
+constexpr std::array<const char*, 6> kInternalSyncTables = {
+  "sync_queue",
+  "_salve_sync_cursors",
+  "_salve_sync_definitions",
+  "_salve_sync_metadata",
+  "_salve_schema_versions",
+  "_salve_relations",
+};
+
+// Internal sync tables (and any sync trigger) only exist once the first registerSchema() call has run.
+bool syncTablesExist(SQLiteConnection& conn) {
+  auto result = conn.execute(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_sync_apply_lock'", {}
+  );
+  return !result.rows.empty();
+}
+
+// Discovered via sqlite_master, not SchemaRegistry — that only reflects schemas registered this process session.
+std::vector<std::string> domainTables(SQLiteConnection& conn) {
+  auto result = conn.execute(
+    "SELECT name FROM sqlite_master WHERE type = 'table' "
+    "AND name NOT LIKE 'sqlite_%' "
+    "AND name NOT LIKE '\\_salve%' ESCAPE '\\' "
+    "AND name NOT IN ('sync_queue', '_sync_apply_lock')",
+    {}
+  );
+
+  std::vector<std::string> tables;
+  tables.reserve(result.rows.size());
+  for (auto& row : result.rows) {
+    if (!row.empty() && std::holds_alternative<std::string>(row[0])) {
+      tables.push_back(std::get<std::string>(row[0]));
+    }
+  }
+  return tables;
+}
+
+std::string quoteIdentifier(const std::string& name) {
+  std::string escaped;
+  for (char c : name) {
+    if (c == '"') escaped += '"';
+    escaped += c;
+  }
+  return "\"" + escaped + "\"";
+}
+
+} // namespace
+
+void DatabaseResetter::reset() {
+  auto& manager = DatabaseManager::shared();
+
+  if (!manager.isOpen()) {
+    CredentialProvider::clearStoredTokens();
+    NativeConfigStore::remove();
+    return;
+  }
+
+  auto conn = manager.connection();
+  auto tables = domainTables(*conn);
+
+  auto wipeDomainTables = [&]() {
+    for (const auto& table : tables) {
+      conn->exec("DELETE FROM " + quoteIdentifier(table));
+    }
+  };
+
+  std::exception_ptr wipeError;
+  try {
+    if (syncTablesExist(*conn)) {
+      // Sync triggers can only exist if registerSchema() ran, i.e. exactly when _sync_apply_lock exists.
+      SyncApplyGuard(conn).applyWithBypass([&]() {
+        wipeDomainTables();
+        for (const char* table : kInternalSyncTables) {
+          conn->exec(std::string("DELETE FROM ") + table);
+        }
+      });
+    } else if (!tables.empty()) {
+      TransactionGuard txn(*conn);
+      wipeDomainTables();
+      txn.commit();
+    }
+  } catch (...) {
+    wipeError = std::current_exception();
+  }
+
+  // Cleared unconditionally even if the wipe above threw — sign-out must not depend on it; wipeError still propagates below.
+  SchemaRegistry::shared().clear();
+  CredentialProvider::clearStoredTokens();
+  manager.resetConfig();
+  NativeConfigStore::remove();
+
+  if (wipeError) std::rethrow_exception(wipeError);
+}
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/database/DatabaseResetter.hpp
+++ b/cpp/database/DatabaseResetter.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace margelo::nitro::salvedb {
+
+/** Implements Database.reset(): wipes all local data and credentials in place, keeping the connection alive. */
+class DatabaseResetter {
+public:
+  // Lock-agnostic — the caller (HybridSalveDatabase::reset()) holds DatabaseManager::shared().lockSync().
+  static void reset();
+};
+
+} // namespace margelo::nitro::salvedb

--- a/cpp/database/NativeConfigStore.cpp
+++ b/cpp/database/NativeConfigStore.cpp
@@ -134,4 +134,8 @@ std::optional<PersistedConfig> NativeConfigStore::load() {
   return config;
 }
 
+void NativeConfigStore::remove() {
+  std::remove(configFilePath().c_str());
+}
+
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/NativeConfigStore.cpp
+++ b/cpp/database/NativeConfigStore.cpp
@@ -1,6 +1,7 @@
 #include "NativeConfigStore.hpp"
 #include "json_parser.hpp"
 #include "../platform/platform.hpp"
+#include <cerrno>
 #include <cstdio>
 #include <fstream>
 #include <sstream>
@@ -135,7 +136,10 @@ std::optional<PersistedConfig> NativeConfigStore::load() {
 }
 
 void NativeConfigStore::remove() {
-  std::remove(configFilePath().c_str());
+  std::string path = configFilePath();
+  if (std::remove(path.c_str()) != 0 && errno != ENOENT) {
+    platform::logError("SalveDb", "NativeConfigStore: failed to remove " + path);
+  }
 }
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/NativeConfigStore.hpp
+++ b/cpp/database/NativeConfigStore.hpp
@@ -34,6 +34,9 @@ class NativeConfigStore {
 public:
   static void save(const PersistedConfig& config);
   static std::optional<PersistedConfig> load();
+
+  // Deletes the persisted config file, if any. No-op if it doesn't exist.
+  static void remove();
 };
 
 } // namespace margelo::nitro::salvedb

--- a/cpp/database/SchemaRegistry.hpp
+++ b/cpp/database/SchemaRegistry.hpp
@@ -22,9 +22,7 @@ public:
   void registerBooleanColumns(const std::string& table, std::unordered_set<std::string> columns);
   bool isBoolean(const std::string& table, const std::string& column) const;
 
-  // Discards all registrations. Must run whenever the underlying SQLite connection
-  // changes (DatabaseManager::open()) — entries are keyed by table name only, not by
-  // db file, so stale entries from a previously-open database would otherwise leak in.
+  // Discards all registrations. Must run whenever the underlying database file changes (DatabaseManager::open(), when reopening a different db) — entries are keyed by table name only, not by db file.
   void clear();
 
 private:

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ set(PROJECT_SOURCES
   "${PROJECT_CPP_DIR}/database/MigrationEngine.cpp"
   "${PROJECT_CPP_DIR}/database/SalveMetadataManager.cpp"
   "${PROJECT_CPP_DIR}/database/SchemaRegistry.cpp"
+  "${PROJECT_CPP_DIR}/database/DatabaseResetter.cpp"
   "${PROJECT_CPP_DIR}/query/QueryExecutor.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncOrchestrator.cpp"
   "${PROJECT_CPP_DIR}/sync/SyncNativeEntryPoint.cpp"

--- a/cpp/tests/HybridSalveDatabaseResetTests.cpp
+++ b/cpp/tests/HybridSalveDatabaseResetTests.cpp
@@ -1,0 +1,239 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../database/DatabaseManager.hpp"
+#include "../database/NativeConfigStore.hpp"
+#include "../platform/platform.hpp"
+#include "support/HybridDatabaseHarness.hpp"
+#include "support/platform_test.hpp"
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using margelo::nitro::salvedb::DatabaseManager;
+using margelo::nitro::salvedb::NativeConfigStore;
+using margelo::nitro::salvedb::platform::deleteSecureValue;
+using margelo::nitro::salvedb::tests::HybridDatabaseHarness;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+void resetSecureStore() {
+  deleteSecureValue("salvedb.credentials.accessToken");
+  deleteSecureValue("salvedb.credentials.refreshToken");
+}
+
+void createDb(HybridDatabaseHarness& harness) {
+  harness.run("(() => { globalThis.db = globalThis.NitroModulesProxy.createHybridObject('SalveDatabase'); return true; })()");
+}
+
+std::string customersSchemaJson() {
+  return R"({
+    name: "customers", version: 1, primaryKey: "id",
+    columns: { id: { type: "text" }, name: { type: "text" }, updatedAt: { type: "datetime", nullable: false } },
+    sync: {
+      enabled: true,
+      endpoint: { basePath: "/customers", sinceParam: "updatedAfter", limitParam: "limit" },
+      pagination: { pageSize: 20, maxPagesPerSession: 20 }
+    }
+  })";
+}
+
+int sqlCount(const std::string& sql) {
+  auto rows = DatabaseManager::shared().connection()->execute(sql, {});
+  return static_cast<int>(std::get<double>(rows.rows[0][0]));
+}
+
+} // namespace
+
+TEST_CASE("db.reset() wipes table rows, and register() alone (no configure()) rebuilds an empty table", "[database][reset]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("reset_data") + "' })");
+
+  std::string schema = R"({
+    name: "reset_probe", version: 1, primaryKey: "id",
+    columns: { id: { type: "integer" } }
+  })";
+  harness.run("db.registerSchema(JSON.stringify(" + schema + "))");
+  harness.run(R"JS(db.execute("INSERT INTO reset_probe (id) VALUES (?)", [1]))JS");
+  harness.run(R"JS(db.execute("INSERT INTO reset_probe (id) VALUES (?)", [2]))JS");
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM reset_probe") == 2);
+
+  harness.run("db.reset()");
+
+  // No configure() call — the connection stays open across reset().
+  harness.run("db.registerSchema(JSON.stringify(" + schema + "))");
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM reset_probe") == 0);
+}
+
+TEST_CASE("db.reset() empties a populated sync_queue without repropagating the deletes", "[database][reset]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("reset_queue") + "' })");
+  harness.run("db.registerSchema(JSON.stringify(" + customersSchemaJson() + "))");
+  harness.run(R"JS(db.execute("INSERT INTO customers (id, name, updatedAt) VALUES (?, ?, ?)", ['1', 'a', 100]))JS");
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM sync_queue WHERE entity = 'customers'") == 1);
+
+  harness.run("db.reset()");
+
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM sync_queue") == 0);
+}
+
+TEST_CASE("db.reset() clears credentials so a later seedInitialTokens isn't silently ignored", "[database][reset][credentials]") {
+  resetSecureStore();
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("reset_creds_a") + R"(',
+    credentials: {
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
+      tokens: { accessToken: 'token-a', refreshToken: 'refresh-a' },
+      refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
+    }
+  }))");
+  REQUIRE(DatabaseManager::shared().credentials().getAccessToken().value() == "token-a");
+
+  harness.run("db.reset()");
+
+  harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("reset_creds_b") + R"(',
+    credentials: {
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
+      tokens: { accessToken: 'token-b', refreshToken: 'refresh-b' },
+      refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
+    }
+  }))");
+
+  REQUIRE(DatabaseManager::shared().credentials().getAccessToken().value() == "token-b");
+}
+
+TEST_CASE("db.reset() resolves without throwing when nothing was ever configured", "[database][reset]") {
+  DatabaseManager::shared().closeForTesting();
+  resetSecureStore();
+
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  REQUIRE_NOTHROW(harness.run("db.reset()"));
+  REQUIRE_FALSE(DatabaseManager::shared().isOpen());
+}
+
+TEST_CASE("db.reset() removes the persisted config file and re-arms platform::scheduleBackgroundSync()", "[database][reset][background]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("reset_background") + R"(',
+    background: { minimumInterval: 900000 }
+  }))");
+  REQUIRE(NativeConfigStore::load().has_value());
+
+  int before = margelo::nitro::salvedb::platform::test::scheduleBackgroundSyncCallCount();
+
+  harness.run("db.reset()");
+
+  REQUIRE(margelo::nitro::salvedb::platform::test::scheduleBackgroundSyncCallCount() == before + 1);
+  REQUIRE_FALSE(NativeConfigStore::load().has_value());
+}
+
+TEST_CASE("db.reset() is serialized against a held sync lock, not run concurrently with it", "[database][reset][concurrency]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("reset_lock") + "' })");
+
+  auto held = DatabaseManager::shared().lockSync();
+
+  std::atomic<bool> resetDone{false};
+  std::thread t([&]() {
+    harness.run("db.reset()");
+    resetDone = true;
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  REQUIRE_FALSE(resetDone.load()); // still waiting on the lock
+
+  held.unlock();
+  t.join();
+  REQUIRE(resetDone.load());
+}
+
+TEST_CASE("DatabaseManager state after db.reset(): connection stays open, config is cleared", "[database][reset]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("reset_state") + R"(',
+    baseUrl: 'https://api.company.com',
+    network: { timeout: 5000 },
+    background: { minimumInterval: 900000 }
+  }))");
+  REQUIRE(DatabaseManager::shared().appConfigured());
+
+  harness.run("db.reset()");
+
+  REQUIRE(DatabaseManager::shared().isOpen());
+  REQUIRE_FALSE(DatabaseManager::shared().appConfigured());
+  REQUIRE_FALSE(DatabaseManager::shared().background().has_value());
+  REQUIRE_THROWS(DatabaseManager::shared().network());
+  REQUIRE_THROWS(DatabaseManager::shared().credentials());
+}
+
+TEST_CASE("db.reset() then register() recreates triggers and metadata cleanly", "[database][reset]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("reset_reregister") + "' })");
+  harness.run("db.registerSchema(JSON.stringify(" + customersSchemaJson() + "))");
+  harness.run(R"JS(db.execute("INSERT INTO customers (id, name, updatedAt) VALUES (?, ?, ?)", ['1', 'a', 100]))JS");
+
+  harness.run("db.reset()");
+  harness.run("db.registerSchema(JSON.stringify(" + customersSchemaJson() + "))");
+
+  harness.run(R"JS(db.execute("INSERT INTO customers (id, name, updatedAt) VALUES (?, ?, ?)", ['2', 'b', 200]))JS");
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM customers") == 1); // '1' was wiped, '2' round-trips
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM sync_queue WHERE entity = 'customers'") == 1);
+}
+
+TEST_CASE("a subscribeToChanges subscription survives reset() followed by configure() with the same name", "[database][reset][notify]") {
+  resetSecureStore();
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  std::string name = uniqueDbName("reset_subscription_survives");
+
+  harness.run(R"(db.configure({
+    name: ')" + name + R"(',
+    credentials: {
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
+      tokens: { accessToken: 'token-a', refreshToken: 'refresh-a' },
+      refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
+    }
+  }))");
+
+  harness.run(R"(
+    (() => {
+      globalThis.__seen = [];
+      globalThis.__subId = db.subscribeToChanges((tables) => { globalThis.__seen.push(tables); });
+      return true;
+    })()
+  )");
+
+  harness.run("db.reset()");
+
+  // Same name — this is the case that used to silently kill the subscription above.
+  harness.run(R"(db.configure({
+    name: ')" + name + R"(',
+    credentials: {
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
+      tokens: { accessToken: 'token-b', refreshToken: 'refresh-b' },
+      refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
+    }
+  }))");
+  harness.run("db.registerSchema(JSON.stringify(" + customersSchemaJson() + "))");
+  harness.run(R"JS(db.execute("INSERT INTO customers (id, name, updatedAt) VALUES (?, ?, ?)", ['1', 'a', 100]))JS");
+
+  // Two coalesced events: registerSchema() touching its own internal tables, then the INSERT
+  // (customers + sync_queue + _salve_sync_metadata, coalesced since they happen in one statement).
+  auto seen = harness.run("globalThis.__seen");
+  REQUIRE(seen == R"([["_salve_schema_versions","_salve_sync_definitions"],["_salve_sync_metadata","customers","sync_queue"]])");
+}

--- a/cpp/tests/HybridSalveDatabaseSubscriptionCleanupTests.cpp
+++ b/cpp/tests/HybridSalveDatabaseSubscriptionCleanupTests.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../HybridSalveDatabase.hpp"
+#include "../database/DatabaseManager.hpp"
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+} // namespace
+
+TEST_CASE("~HybridSalveDatabase() unsubscribes its own subscriptions from the still-open connection", "[database][notify][cleanup]") {
+  DatabaseManager::shared().open(uniqueDbName("subscription_cleanup"));
+  auto conn = DatabaseManager::shared().connection();
+  conn->exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+
+  int callCount = 0;
+  {
+    auto db = std::make_shared<HybridSalveDatabase>();
+    db->subscribeToChanges([&](const std::vector<std::string>&) { callCount++; });
+
+    conn->execute("INSERT INTO t (id) VALUES (?)", {1.0});
+    REQUIRE(callCount == 1);
+  } // db destructs here — must unsubscribe, since DatabaseManager keeps the same connection alive.
+
+  conn->execute("INSERT INTO t (id) VALUES (?)", {2.0});
+  REQUIRE(callCount == 1); // unchanged — the dead subscription no longer fires
+}

--- a/cpp/tests/database/DatabaseManagerOpenIdempotencyTests.cpp
+++ b/cpp/tests/database/DatabaseManagerOpenIdempotencyTests.cpp
@@ -1,0 +1,70 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/DatabaseManager.hpp"
+#include "../../database/MigrationEngine.hpp"
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+std::string journalMode(SQLiteConnection& conn) {
+  auto result = conn.execute("PRAGMA journal_mode", {});
+  return std::get<std::string>(result.rows[0][0]);
+}
+
+} // namespace
+
+TEST_CASE("open() with the same name and walMode reuses the existing connection", "[database][DatabaseManager][open]") {
+  auto name = uniqueDbName("idempotent_same");
+  DatabaseManager::shared().open(name);
+  auto before = DatabaseManager::shared().connection();
+
+  DatabaseManager::shared().open(name);
+
+  REQUIRE(DatabaseManager::shared().connection() == before);
+}
+
+TEST_CASE("open() with a different walMode for the same name recreates the connection", "[database][DatabaseManager][open]") {
+  auto name = uniqueDbName("idempotent_walmode");
+  DatabaseManager::shared().open(name, true);
+  auto before = DatabaseManager::shared().connection();
+  REQUIRE(journalMode(*before) == "wal");
+
+  DatabaseManager::shared().open(name, false);
+
+  REQUIRE(DatabaseManager::shared().connection() != before);
+  REQUIRE(journalMode(*DatabaseManager::shared().connection()) == "delete");
+}
+
+TEST_CASE("open() with a different name recreates the connection", "[database][DatabaseManager][open]") {
+  DatabaseManager::shared().open(uniqueDbName("idempotent_name_a"));
+  auto before = DatabaseManager::shared().connection();
+
+  DatabaseManager::shared().open(uniqueDbName("idempotent_name_b"));
+
+  REQUIRE(DatabaseManager::shared().connection() != before);
+}
+
+TEST_CASE("open() reusing the connection preserves SchemaRegistry — boolean coercion survives a repeat configure()", "[database][DatabaseManager][open][SchemaRegistry]") {
+  auto name = uniqueDbName("idempotent_schema_registry");
+  DatabaseManager::shared().open(name);
+  auto conn = DatabaseManager::shared().connection();
+
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "flags", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" }, "active": { "type": "boolean" } }
+  })"));
+  conn->execute("INSERT INTO flags (id, active) VALUES (?, ?)", {1.0, true});
+
+  // Simulates a repeat Database.configure() with the same name — no reset() in between.
+  DatabaseManager::shared().open(name);
+
+  auto result = DatabaseManager::shared().connection()->execute("SELECT active FROM flags WHERE id = ?", {1.0});
+  REQUIRE(std::holds_alternative<bool>(result.rows[0][0]));
+  REQUIRE(std::get<bool>(result.rows[0][0]) == true);
+}

--- a/cpp/tests/database/DatabaseManagerOpenIdempotencyTests.cpp
+++ b/cpp/tests/database/DatabaseManagerOpenIdempotencyTests.cpp
@@ -31,12 +31,14 @@ TEST_CASE("open() with the same name and walMode reuses the existing connection"
 TEST_CASE("open() with a different walMode for the same name recreates the connection", "[database][DatabaseManager][open]") {
   auto name = uniqueDbName("idempotent_walmode");
   DatabaseManager::shared().open(name, true);
-  auto before = DatabaseManager::shared().connection();
-  REQUIRE(journalMode(*before) == "wal");
+  auto* beforeRaw = DatabaseManager::shared().connection().get();
+  REQUIRE(journalMode(*DatabaseManager::shared().connection()) == "wal");
 
+  // journal_mode=DELETE needs exclusive access — don't hold our own reference to the WAL
+  // connection while opening the replacement, on top of whatever DatabaseManager itself holds.
   DatabaseManager::shared().open(name, false);
 
-  REQUIRE(DatabaseManager::shared().connection() != before);
+  REQUIRE(DatabaseManager::shared().connection().get() != beforeRaw);
   REQUIRE(journalMode(*DatabaseManager::shared().connection()) == "delete");
 }
 

--- a/cpp/tests/database/DatabaseResetterTests.cpp
+++ b/cpp/tests/database/DatabaseResetterTests.cpp
@@ -1,0 +1,94 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../../database/DatabaseManager.hpp"
+#include "../../database/DatabaseResetter.hpp"
+#include "../../database/MigrationEngine.hpp"
+#include <algorithm>
+#include <vector>
+
+using namespace margelo::nitro::salvedb;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+// One plain schema, one sync-enabled — proves table discovery isn't limited to sync.enabled schemas.
+std::shared_ptr<SQLiteConnection> openResetterFixture(const std::string& testName) {
+  DatabaseManager::shared().open(uniqueDbName(testName));
+  auto conn = DatabaseManager::shared().connection();
+
+  MigrationEngine engine(conn);
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "widgets", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "integer" } }
+  })"));
+  engine.registerSchema(MigrationEngine::parseSchemaJson(R"({
+    "name": "customers", "version": 1, "primaryKey": "id",
+    "columns": { "id": { "type": "text" }, "updatedAt": { "type": "datetime", "nullable": false } },
+    "sync": {
+      "enabled": true,
+      "endpoint": { "basePath": "/customers", "sinceParam": "updatedAfter", "limitParam": "limit" },
+      "pagination": { "pageSize": 20, "maxPagesPerSession": 20 }
+    }
+  })"));
+
+  return conn;
+}
+
+int rowCount(SQLiteConnection& conn, const std::string& table) {
+  auto rows = conn.execute("SELECT COUNT(*) FROM \"" + table + "\"", {});
+  return static_cast<int>(std::get<double>(rows.rows[0][0]));
+}
+
+} // namespace
+
+TEST_CASE("DatabaseResetter::reset() wipes every domain table, regardless of sync.enabled", "[database][DatabaseResetter]") {
+  auto conn = openResetterFixture("resetter_multi_schema");
+  conn->execute("INSERT INTO widgets (id) VALUES (?)", {1.0});
+  conn->execute("INSERT INTO customers (id, updatedAt) VALUES (?, ?)", {std::string("c1"), 100.0});
+  REQUIRE(rowCount(*conn, "widgets") == 1);
+  REQUIRE(rowCount(*conn, "customers") == 1);
+
+  DatabaseResetter::reset();
+
+  REQUIRE(rowCount(*conn, "widgets") == 0);
+  REQUIRE(rowCount(*conn, "customers") == 0);
+}
+
+TEST_CASE("DatabaseResetter::reset() fires exactly one coalesced notification listing only the wiped domain tables", "[database][DatabaseResetter][notify]") {
+  auto conn = openResetterFixture("resetter_notify");
+  conn->execute("INSERT INTO widgets (id) VALUES (?)", {1.0});
+  conn->execute("INSERT INTO customers (id, updatedAt) VALUES (?, ?)", {std::string("c1"), 100.0});
+
+  std::vector<std::vector<std::string>> received;
+  int subId = conn->subscribe([&](std::vector<std::string> tables) { received.push_back(std::move(tables)); });
+
+  DatabaseResetter::reset();
+
+  conn->unsubscribe(subId);
+
+  REQUIRE(received.size() == 1); // one transaction, one coalesced notification
+
+  auto tables = received[0];
+  std::sort(tables.begin(), tables.end());
+  // _sync_apply_lock shows up too: SyncApplyGuard's INSERT into it isn't subject to the truncate optimization that hides internal tables' DELETEs.
+  REQUIRE(tables == std::vector<std::string>{"_sync_apply_lock", "customers", "widgets"});
+}
+
+TEST_CASE("DatabaseResetter::reset() leaves no stray row behind in _sync_apply_lock", "[database][DatabaseResetter]") {
+  auto conn = openResetterFixture("resetter_apply_lock");
+  conn->execute("INSERT INTO widgets (id) VALUES (?)", {1.0});
+
+  DatabaseResetter::reset();
+
+  REQUIRE(rowCount(*conn, "_sync_apply_lock") == 0);
+}
+
+TEST_CASE("DatabaseResetter::reset() is a no-op that doesn't throw when the database was never opened", "[database][DatabaseResetter]") {
+  DatabaseManager::shared().closeForTesting();
+
+  REQUIRE_NOTHROW(DatabaseResetter::reset());
+  REQUIRE_FALSE(DatabaseManager::shared().isOpen());
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1939,7 +1939,7 @@ PODS:
     - React-utils (= 0.86.0)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.86.0)
-  - SalveDb (0.1.0):
+  - SalveDb (0.1.1):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -2286,7 +2286,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 1973e629fe2614a7b2cf72919cb9935b6c34675f
   ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  SalveDb: 7fde6f8d088bee4aeddde27375fa2c02f7cfbc8c
+  SalveDb: c9d225fdca0b6ee1bf26697372566eac2aa0640f
   Yoga: fe50ab299e578f397fef753cf309c6703a4db29b
 
 PODFILE CHECKSUM: e1823b20150f420cb2568adef65d05a5d5c7241b

--- a/example/src/__harness__/SalveDb.reset.harness.tsx
+++ b/example/src/__harness__/SalveDb.reset.harness.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect } from 'react';
+import { describe, it, expect, render, waitFor } from 'react-native-harness';
+import { Database, SalveDbProvider, useQuery } from '@salve-software/react-native-salve-db';
+import type { AnySchema } from '@salve-software/react-native-salve-db';
+
+function uniqueName(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+}
+
+/** MigrationEngine injects `deletedAt` into every schema, sync-enabled or not — a live row always carries it as `null`. */
+function row(id: number): { id: number; deletedAt: null } {
+  return { id, deletedAt: null };
+}
+
+describe('Database.reset — wipes local data, connection stays usable', () => {
+  it('clears rows, and register() alone — no configure() — rebuilds the schema', async () => {
+    Database.configure({ name: uniqueName('e2e_reset_data') });
+    const schema: AnySchema = {
+      name: 'reset_probe',
+      version: 1,
+      primaryKey: 'id',
+      columns: { id: { type: 'integer' } },
+    };
+    await Database.register({ schema });
+
+    Database.insert(schema).values({ id: 1 }).execute();
+    Database.insert(schema).values({ id: 2 }).execute();
+    expect(Database.select(schema).limit(10).execute()).toHaveLength(2);
+
+    await Database.reset();
+
+    // No configure() call here — the connection stays open across reset().
+    await Database.register({ schema });
+    expect(Database.select(schema).limit(10).execute()).toHaveLength(0);
+  });
+
+  it('empties a populated sync_queue without repropagating the deletes', async () => {
+    Database.configure({ name: uniqueName('e2e_reset_queue') });
+    const schema: AnySchema = {
+      name: 'reset_sync_probe',
+      version: 1,
+      primaryKey: 'id',
+      columns: {
+        id: { type: 'integer' },
+        updatedAt: { type: 'datetime', nullable: false },
+      },
+      sync: {
+        enabled: true,
+        direction: 'bidirectional',
+        conflict: 'lastWriteWins',
+        transport: 'rest',
+        endpoint: { basePath: '/reset_sync_probe', sinceParam: 'updatedAfter', limitParam: 'limit' },
+        pagination: { pageSize: 20, maxPagesPerSession: 20 },
+      },
+    };
+    await Database.register({ schema });
+
+    Database.insert(schema).values({ id: 1, updatedAt: Date.now() }).execute();
+    expect(
+      (Database.execute('SELECT COUNT(*) as count FROM sync_queue') as { count: number }[])[0].count
+    ).toBe(1);
+
+    await Database.reset();
+
+    expect(
+      (Database.execute('SELECT COUNT(*) as count FROM sync_queue') as { count: number }[])[0].count
+    ).toBe(0);
+  });
+});
+
+type UseQueryResultOf<TSchema extends AnySchema> = ReturnType<typeof useQuery<TSchema>>;
+
+function QueryProbe<TSchema extends AnySchema>({ schema, onResult }: {
+  schema: TSchema;
+  onResult: (result: UseQueryResultOf<TSchema>) => void;
+}) {
+  const result = useQuery({ schema, queryFn: (q) => q.orderBy('id', 'asc').limit(50) });
+  useEffect(() => onResult(result));
+  return null;
+}
+
+describe('useQuery — reflects Database.reset() without remounting the provider', () => {
+  it('a live query goes back to empty after reset() + register(), no SalveDbProvider remount', async () => {
+    const schema = {
+      name: uniqueName('hook_reset'),
+      version: 1,
+      primaryKey: 'id',
+      columns: { id: { type: 'integer' } },
+    } satisfies AnySchema;
+    const config = { name: uniqueName('e2e_reset_reactive') };
+
+    let latest: UseQueryResultOf<typeof schema> | undefined;
+
+    await render(
+      <SalveDbProvider config={config} schemas={[schema]}>
+        <QueryProbe schema={schema} onResult={(result) => { latest = result; }} />
+      </SalveDbProvider>
+    );
+
+    await waitFor(() => expect(latest?.data).toEqual([]));
+
+    Database.insert(schema).values({ id: 1 }).execute();
+    await waitFor(() => expect(latest?.data).toEqual([row(1)]));
+
+    await Database.reset();
+    await Database.register({ schema }); // no remount — the provider stays mounted
+
+    await waitFor(() => expect(latest?.data).toEqual([]));
+  });
+
+  it('keeps reacting after reset() + configure() with the same name + register(), no remount', async () => {
+    const schema = {
+      name: uniqueName('hook_reset_reconfigure'),
+      version: 1,
+      primaryKey: 'id',
+      columns: { id: { type: 'integer' } },
+    } satisfies AnySchema;
+    const configName = uniqueName('e2e_reset_reconfigure');
+
+    let latest: UseQueryResultOf<typeof schema> | undefined;
+
+    await render(
+      <SalveDbProvider config={{ name: configName }} schemas={[schema]}>
+        <QueryProbe schema={schema} onResult={(result) => { latest = result; }} />
+      </SalveDbProvider>
+    );
+
+    await waitFor(() => expect(latest?.data).toEqual([]));
+
+    Database.insert(schema).values({ id: 1 }).execute();
+    await waitFor(() => expect(latest?.data).toEqual([row(1)]));
+
+    await Database.reset();
+    Database.configure({ name: configName }); // same name — used to silently kill this exact subscription
+    await Database.register({ schema });
+
+    await waitFor(() => expect(latest?.data).toEqual([]));
+
+    // Proves the subscription is still alive, not just that the wipe was observed once.
+    Database.insert(schema).values({ id: 2 }).execute();
+    await waitFor(() => expect(latest?.data).toEqual([row(2)]));
+  });
+});

--- a/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.cpp
@@ -16,6 +16,7 @@ namespace margelo::nitro::salvedb {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridMethod("configure", &HybridSalveDatabaseSpec::configure);
       prototype.registerHybridMethod("registerSchema", &HybridSalveDatabaseSpec::registerSchema);
+      prototype.registerHybridMethod("reset", &HybridSalveDatabaseSpec::reset);
       prototype.registerHybridMethod("execute", &HybridSalveDatabaseSpec::execute);
       prototype.registerHybridMethod("beginTransaction", &HybridSalveDatabaseSpec::beginTransaction);
       prototype.registerHybridMethod("commit", &HybridSalveDatabaseSpec::commit);

--- a/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.hpp
@@ -65,6 +65,7 @@ namespace margelo::nitro::salvedb {
       // Methods
       virtual void configure(const ConfigureParams& params) = 0;
       virtual std::shared_ptr<Promise<void>> registerSchema(const std::string& schemaJson) = 0;
+      virtual std::shared_ptr<Promise<void>> reset() = 0;
       virtual QueryResult execute(const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params) = 0;
       virtual void beginTransaction() = 0;
       virtual void commit() = 0;

--- a/src/database/Database.class.ts
+++ b/src/database/Database.class.ts
@@ -36,7 +36,7 @@ export class Database {
     return this.configureDb.register(props)
   }
 
-  /** Wipes all local data and credentials — full sign-out; call `configure` again, then `register` per schema. */
+  /** Wipes all local data and credentials — full sign-out; `register` per schema resumes local use, `configure` again is only needed to restore sync. */
   static reset = () => {
     return this.configureDb.reset()
   }

--- a/src/database/Database.class.ts
+++ b/src/database/Database.class.ts
@@ -36,6 +36,11 @@ export class Database {
     return this.configureDb.register(props)
   }
 
+  /** Wipes all local data and credentials — full sign-out; call `configure` again, then `register` per schema. */
+  static reset = () => {
+    return this.configureDb.reset()
+  }
+
   /** Starts a `SELECT` against `schema`'s table. Call `.execute()` on the returned builder to run it. */
   static select = <TSchema extends AnySchema>(schema: TSchema) => {
     return this.queryDb.select(schema);

--- a/src/database/classes/ConfigureDb/ConfigureDb.class.ts
+++ b/src/database/classes/ConfigureDb/ConfigureDb.class.ts
@@ -64,6 +64,11 @@ export class ConfigureDb {
     return this._bridge.registerSchema(JSON.stringify(schema));
   }
 
+  /** Wipes all local data and credentials; call `configure()` again, then `register()` per schema. */
+  reset(): Promise<void> {
+    return this._bridge.reset();
+  }
+
   static isConfigured(): boolean {
     return ConfigureDb._configured;
   }

--- a/src/database/classes/ConfigureDb/ConfigureDb.class.ts
+++ b/src/database/classes/ConfigureDb/ConfigureDb.class.ts
@@ -64,7 +64,7 @@ export class ConfigureDb {
     return this._bridge.registerSchema(JSON.stringify(schema));
   }
 
-  /** Wipes all local data and credentials; call `configure()` again, then `register()` per schema. */
+  /** Wipes all local data and credentials; `register()` per schema resumes local use, `configure()` again is only needed to restore sync. */
   reset(): Promise<void> {
     return this._bridge.reset();
   }

--- a/src/database/classes/ConfigureDb/__tests__/ConfigureDb.reset.test.ts
+++ b/src/database/classes/ConfigureDb/__tests__/ConfigureDb.reset.test.ts
@@ -1,0 +1,47 @@
+jest.mock('react-native', () => ({
+  AppState: { currentState: 'active', addEventListener: jest.fn() },
+  Platform: { OS: 'ios' },
+}));
+
+import { ConfigureDb } from '../ConfigureDb.class';
+import type { SalveDatabase } from '../../../../specs/SalveDatabase.nitro';
+
+function makeBridge() {
+  return {
+    configure: jest.fn(),
+    reset: jest.fn().mockResolvedValue(undefined),
+  } as unknown as SalveDatabase;
+}
+
+describe('ConfigureDb.reset()', () => {
+  test('calls bridge.reset() and forwards its resolved value', async () => {
+    const bridge = makeBridge();
+
+    await expect(new ConfigureDb(bridge).reset()).resolves.toBeUndefined();
+
+    expect(bridge.reset).toHaveBeenCalledWith();
+  });
+
+  test('propagates a bridge rejection instead of swallowing it', async () => {
+    const bridge = makeBridge();
+    (bridge.reset as jest.Mock).mockRejectedValue(new Error('native wipe failed'));
+
+    await expect(new ConfigureDb(bridge).reset()).rejects.toThrow('native wipe failed');
+  });
+
+  test('does not throw synchronously when configure() was never called', () => {
+    const bridge = makeBridge();
+
+    expect(() => new ConfigureDb(bridge).reset()).not.toThrow();
+  });
+
+  test('does not flip ConfigureDb.isConfigured() back to false', async () => {
+    const bridge = makeBridge();
+    new ConfigureDb(bridge).configure({ name: 'db' });
+    expect(ConfigureDb.isConfigured()).toBe(true);
+
+    await new ConfigureDb(bridge).reset();
+
+    expect(ConfigureDb.isConfigured()).toBe(true);
+  });
+});

--- a/src/specs/SalveDatabase.nitro.ts
+++ b/src/specs/SalveDatabase.nitro.ts
@@ -14,6 +14,9 @@ export interface SalveDatabase extends HybridObject<{ ios: "c++"; android: "c++"
    */
   registerSchema(schemaJson: string): Promise<void>;
 
+  /** Wipes all local data and credentials in place; call `configure()` again, then `register()` per schema. */
+  reset(): Promise<void>;
+
   // ── Query ──────────────────────────────────────────────────────────────────
 
   /**

--- a/src/specs/SalveDatabase.nitro.ts
+++ b/src/specs/SalveDatabase.nitro.ts
@@ -14,7 +14,7 @@ export interface SalveDatabase extends HybridObject<{ ios: "c++"; android: "c++"
    */
   registerSchema(schemaJson: string): Promise<void>;
 
-  /** Wipes all local data and credentials in place; call `configure()` again, then `register()` per schema. */
+  /** Wipes all local data and credentials in place; `register()` per schema resumes local use, `configure()` again is only needed to restore sync. */
   reset(): Promise<void>;
 
   // ── Query ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements TASK / issue #112 — `Database.reset(): Promise<void>`, a full local sign-out: wipes every
domain table and internal sync table in place, clears stored OAuth2 credentials from
Keychain/Keystore, and clears in-memory config (network/credentials/background) while keeping the
SQLite connection alive so `useQuery`/`subscribeToChanges` subscribers stay reactive without a
`SalveDbProvider` remount.

- `DatabaseResetter::reset()` — the wipe: domain tables discovered via `sqlite_master`, internal sync
  tables wiped inside one `SyncApplyGuard`-bypassed transaction, credentials/config cleared
  unconditionally even if the SQL wipe fails.
- `DatabaseManager::open()` is now idempotent for the same file+walMode — a repeat `configure()`
  (e.g. re-seeding a new user's credentials after `reset()`) no longer recreates the SQLite
  connection, so it doesn't silently kill existing native subscriptions. Closed the one regression
  this introduces (a dev-reload subscriber leak) with a destructor on `HybridSalveDatabase` that
  unsubscribes its own ids.
- `Database.reset()` exposed in the public TS API (`Database.reset()` / `ConfigureDb.reset()`), no
  configured-guard by design — it's a safe no-op-but-still-clear when `configure()` was never called.

Caller contract after `reset()`: `register()` again per schema (schemas aren't persisted natively);
`configure()` again only if sync/credentials are needed, and it's now safe to call with the same
`name` without losing reactivity.

Reviewed twice by an independent Opus agent during development — round 1 caught and fixed a real
deadlock (`scheduleBackgroundSync()` called while still holding the sync lock) and a data-wipe gap
(skipped wiping user tables when no schema was ever registered); round 2 investigated the
`open()`-idempotency tradeoffs before implementing it. Both are reflected in the commits.

## Test plan

- [x] `npm run test:native` — 293 native C++ test cases (Catch2 + real Hermes/JSI), all green
- [x] `npm run test` (Jest) — 196 tests, all green
- [x] `npm run typecheck` / `npm run build` — clean
- [ ] iOS/Android device harness (`example/src/__harness__/SalveDb.reset.harness.tsx`) — written and
      typechecked; on-device execution was blocked by local environment issues in this session
      (stale CocoaPods now fixed, but Keychain-entitlement/Metro-cache flakiness on the available
      simulators was unrelated to this change and not resolved here) — worth a clean run before
      merge if a stable device/simulator is available.

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a database reset API that clears local data, synchronization state, credentials, and saved configuration.
  * Reset can be performed asynchronously without replacing the active database connection.
  * Added credential and configuration removal capabilities.
* **Improvements**
  * Reused existing database connections when configuration is unchanged.
  * Preserved subscriptions and reactive queries across resets and compatible reconfiguration.
  * Automatically cleaned up subscriptions when database instances are destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->