### PR TITLE
feat(example): add Database.reset() QA controls

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -14,6 +14,7 @@ import { InfiniteQueryScreen } from './src/screens/InfiniteQueryScreen';
 import { BenchmarkScreen } from './src/screens/BenchmarkScreen';
 import { SyncTestScreen } from './src/screens/SyncTestScreen';
 import { LoginScreen, type LoginTokens } from './src/screens/LoginScreen';
+import { ResetControls } from './src/components/ResetControls';
 import { SYNC_SERVER_BASE_URL } from './src/library/syncServer';
 
 if (__DEV__) {
@@ -31,20 +32,49 @@ const TABS = [
 
 type TabKey = (typeof TABS)[number]['key'];
 
-interface AppTabsProps {
-  accessToken: string;
+const SCHEMAS = [
+  ExpenseSchema,
+  BudgetSchema,
+  BenchmarkSchema,
+  FeedItemSchema,
+  UserSchema,
+  ProductSchema,
+];
+
+/** Shared by the initial SalveDbProvider mount and ResetControls' "reconfigure" button — same db name both times, so the connection (and its subscriptions) survives a reset(). */
+function buildDbConfig(tokens: LoginTokens) {
+  return {
+    name: 'salve-db-example',
+    baseUrl: SYNC_SERVER_BASE_URL,
+    network: { timeout: 5000 },
+    credentials: {
+      provider: 'oauth2' as const,
+      tokens,
+      refresh: {
+        endpoint: '/auth/refresh',
+        response: { accessToken: '$.accessToken', refreshToken: '$.refreshToken' },
+      },
+    },
+    background: { minimumInterval: 15 * 60 * 1000, requiresNetwork: false },
+  };
 }
 
-function AppTabs({ accessToken }: AppTabsProps): React.JSX.Element {
+interface AppTabsProps {
+  tokens: LoginTokens;
+}
+
+function AppTabs({ tokens }: AppTabsProps): React.JSX.Element {
   const [tab, setTab] = useState<TabKey>('expenses');
 
   return (
     <View style={styles.flex}>
+      <ResetControls schemas={SCHEMAS} buildConfig={() => buildDbConfig(tokens)} />
+
       <View style={styles.flex}>
         {tab === 'expenses' ? <ExpensesScreen /> : null}
         {tab === 'infinite' ? <InfiniteQueryScreen /> : null}
         {tab === 'benchmark' ? <BenchmarkScreen /> : null}
-        {tab === 'sync' ? <SyncTestScreen accessToken={accessToken} /> : null}
+        {tab === 'sync' ? <SyncTestScreen accessToken={tokens.accessToken} /> : null}
       </View>
 
       <SafeAreaView style={styles.tabBar} edges={['bottom']}>
@@ -72,31 +102,8 @@ function App(): React.JSX.Element {
 
   return (
     <SafeAreaProvider>
-      <SalveDbProvider
-        config={{
-          name: 'salve-db-example',
-          baseUrl: SYNC_SERVER_BASE_URL,
-          network: { timeout: 5000 },
-          credentials: {
-            provider: 'oauth2',
-            tokens,
-            refresh: {
-              endpoint: '/auth/refresh',
-              response: { accessToken: '$.accessToken', refreshToken: '$.refreshToken' },
-            },
-          },
-          background: { minimumInterval: 15 * 60 * 1000, requiresNetwork: false },
-        }}
-        schemas={[
-          ExpenseSchema,
-          BudgetSchema,
-          BenchmarkSchema,
-          FeedItemSchema,
-          UserSchema,
-          ProductSchema,
-        ]}
-      >
-        <AppTabs accessToken={tokens.accessToken} />
+      <SalveDbProvider config={buildDbConfig(tokens)} schemas={SCHEMAS}>
+        <AppTabs tokens={tokens} />
       </SalveDbProvider>
     </SafeAreaProvider>
   );

--- a/example/src/__harness__/SalveDb.reset.harness.tsx
+++ b/example/src/__harness__/SalveDb.reset.harness.tsx
@@ -47,7 +47,7 @@ describe('Database.reset — wipes local data, connection stays usable', () => {
       sync: {
         enabled: true,
         direction: 'bidirectional',
-        conflict: 'lastWriteWins',
+        conflict: { strategy: 'lastWriteWins' },
         transport: 'rest',
         endpoint: { basePath: '/reset_sync_probe', sinceParam: 'updatedAfter', limitParam: 'limit' },
         pagination: { pageSize: 20, maxPagesPerSession: 20 },

--- a/example/src/components/ResetControls.tsx
+++ b/example/src/components/ResetControls.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { AnySchema } from '@salve-software/react-native-salve-db';
+import { Database } from '@salve-software/react-native-salve-db';
+
+const ACCENT = '#5B5FEF';
+const DANGER = '#E14F62';
+
+type ConfigureProps = Parameters<typeof Database.configure>[0];
+
+interface ResetControlsProps {
+  schemas: AnySchema[];
+  buildConfig: () => ConfigureProps;
+}
+
+/**
+ * Manual QA surface for Database.reset(): "Reset (local)" proves the wipe +
+ * reactivity without touching sync; "Reset + Reconfigure" additionally calls
+ * configure() again with the same db name, proving the connection (and every
+ * useQuery subscription mounted anywhere in the tab tree) survives instead of
+ * silently going stale.
+ */
+export function ResetControls({ schemas, buildConfig }: ResetControlsProps): React.JSX.Element {
+  const [busy, setBusy] = useState(false);
+  const [lastResult, setLastResult] = useState<string | null>(null);
+
+  async function registerAllSchemas() {
+    for (const schema of schemas) {
+      await Database.register({ schema });
+    }
+  }
+
+  async function resetLocal() {
+    setBusy(true);
+    setLastResult(null);
+    try {
+      await Database.reset();
+      await registerAllSchemas();
+      setLastResult('Reset (local) ok — data wiped, sync needs configure() again to resume.');
+    } catch (err) {
+      setLastResult(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function resetAndReconfigure() {
+    setBusy(true);
+    setLastResult(null);
+    try {
+      await Database.reset();
+      Database.configure(buildConfig());
+      await registerAllSchemas();
+      setLastResult('Reset + Reconfigure ok — same db name, sync restored, no remount.');
+    } catch (err) {
+      setLastResult(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.buttonRow}>
+        <Pressable style={[styles.button, busy && styles.buttonDisabled]} disabled={busy} onPress={resetLocal}>
+          <Text style={styles.buttonText}>Reset (local)</Text>
+        </Pressable>
+        <Pressable style={[styles.button, styles.buttonDanger, busy && styles.buttonDisabled]} disabled={busy} onPress={resetAndReconfigure}>
+          <Text style={styles.buttonDangerText}>Reset + Reconfigure</Text>
+        </Pressable>
+      </View>
+      {busy ? <ActivityIndicator color={ACCENT} style={styles.spinner} /> : null}
+      {lastResult ? (
+        <Text style={[styles.resultText, lastResult.startsWith('Error') && styles.errorText]} numberOfLines={2}>
+          {lastResult}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 10,
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#E1E2F0',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  button: {
+    flex: 1,
+    height: 34,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F4F5FA',
+  },
+  buttonDanger: {
+    backgroundColor: DANGER,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#1C1D3E',
+  },
+  buttonDangerText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#FFFFFF',
+  },
+  spinner: {
+    marginTop: 6,
+  },
+  resultText: {
+    marginTop: 6,
+    fontSize: 11,
+    color: '#4A4D7A',
+    fontWeight: '500',
+  },
+  errorText: {
+    color: DANGER,
+  },
+});

--- a/example/src/components/ResetControls.tsx
+++ b/example/src/components/ResetControls.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import type { AnySchema } from '@salve-software/react-native-salve-db';
 import { Database } from '@salve-software/react-native-salve-db';
 
@@ -60,7 +61,7 @@ export function ResetControls({ schemas, buildConfig }: ResetControlsProps): Rea
   }
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.buttonRow}>
         <Pressable style={[styles.button, busy && styles.buttonDisabled]} disabled={busy} onPress={resetLocal}>
           <Text style={styles.buttonText}>Reset (local)</Text>
@@ -75,7 +76,7 @@ export function ResetControls({ schemas, buildConfig }: ResetControlsProps): Rea
           {lastResult}
         </Text>
       ) : null}
-    </View>
+    </SafeAreaView>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a manual QA surface in the example app for `Database.reset()` (#112/#113), plus a small unrelated typecheck fix uncovered while getting `develop` clean for this branch.

- **`ResetControls`** — a persistent header above the tab content in `AppTabs`, visible regardless of active tab, with two buttons:
  - **"Reset (local)"**: `Database.reset()` + `register()` per schema. Proves the wipe and reactivity; sync stays unavailable until a fresh `configure()`.
  - **"Reset + Reconfigure"**: `Database.reset()` + `Database.configure()` with the *same* db name (reusing the tokens already held in `App` state) + `register()` per schema. Proves the connection — and every mounted `useQuery` subscription — survives, since `DatabaseManager::open()` no longer recreates it for a matching file.
- Extracted `SCHEMAS` and `buildDbConfig()` out of the inline `SalveDbProvider` JSX in `App.tsx` so the reconfigure button builds the exact same config shape as the initial mount instead of duplicating it, and threaded the full `LoginTokens` down to `AppTabs` (previously only `accessToken` was passed).
- Fixed `SalveDb.reset.harness.tsx`'s `conflict` config to the new `{ strategy, field? }` object shape — it typechecked against `lastWriteWins` as a plain string before #111 (feat/conflict-strategies) merged, which landed after that harness file was written.

## Verified on-device

Ran the actual example app (iPhone 16 simulator, real login against local `salve-db-server`), not just typecheck:
- Added an expense, tapped **Reset (local)** — list emptied reactively, no crash.
- Added another, tapped **Reset + Reconfigure** — emptied again, and a subsequent insert into the *same mounted* query kept showing up — confirms the subscription survives reconfigure, not just the wipe.
- Found and fixed a real bug during this pass: the header rendered under the status bar/notch (no top safe-area inset) — fixed with `SafeAreaView edges={['top']}`.
- Confirmed via native iOS logs that credentials/network were genuinely restored after "Reset + Reconfigure" (the sync request reached the server and got a real HTTP 500 back — a local `salve-db-server` issue unrelated to this change — rather than failing at the native "not configured" guard).

## Test plan

- [x] `npm run typecheck` (root + example) — clean
- [x] `npm run test` (Jest) — 192/192
- [x] Manual on-device verification (see above)