### PR TITLE
feat: Database.logout()

### DIFF
--- a/cpp/HybridSalveDatabase.cpp
+++ b/cpp/HybridSalveDatabase.cpp
@@ -3,6 +3,7 @@
 #include "database/DatabaseResetter.hpp"
 #include "database/MigrationEngine.hpp"
 #include "database/NativeConfigStore.hpp"
+#include "credentials/CredentialProvider.hpp"
 #include "platform/platform.hpp"
 #include <algorithm>
 #include <cmath>
@@ -111,6 +112,13 @@ std::shared_ptr<Promise<void>> HybridSalveDatabase::reset() {
     // Outside the lock, like configure() — scheduleBackgroundSync() re-locks synchronously and would self-deadlock otherwise.
     platform::scheduleBackgroundSync();
   });
+}
+
+void HybridSalveDatabase::logout() {
+  // Serialized against the sync lock, like configure()/reset() — avoids
+  // racing an in-flight refresh() that reads/writes the same Keychain keys.
+  auto lock = DatabaseManager::shared().lockSync();
+  CredentialProvider::clearStoredTokens();
 }
 
 QueryResult HybridSalveDatabase::execute(

--- a/cpp/HybridSalveDatabase.hpp
+++ b/cpp/HybridSalveDatabase.hpp
@@ -22,6 +22,7 @@ public:
   void configure(const ConfigureParams& params) override;
   std::shared_ptr<Promise<void>> registerSchema(const std::string& schemaJson) override;
   std::shared_ptr<Promise<void>> reset() override;
+  void logout() override;
   QueryResult execute(const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params) override;
   void beginTransaction() override;
   void commit() override;

--- a/cpp/tests/HybridSalveDatabaseLogoutTests.cpp
+++ b/cpp/tests/HybridSalveDatabaseLogoutTests.cpp
@@ -1,0 +1,141 @@
+#include <catch2/catch_test_macros.hpp>
+#include "../database/DatabaseManager.hpp"
+#include "../platform/platform.hpp"
+#include "support/HybridDatabaseHarness.hpp"
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using margelo::nitro::salvedb::DatabaseManager;
+using margelo::nitro::salvedb::platform::deleteSecureValue;
+using margelo::nitro::salvedb::tests::HybridDatabaseHarness;
+
+namespace {
+
+std::string uniqueDbName(const std::string& testName) {
+  static int counter = 0;
+  return testName + "_" + std::to_string(++counter);
+}
+
+void resetSecureStore() {
+  deleteSecureValue("salvedb.credentials.accessToken");
+  deleteSecureValue("salvedb.credentials.refreshToken");
+}
+
+void createDb(HybridDatabaseHarness& harness) {
+  harness.run("(() => { globalThis.db = globalThis.NitroModulesProxy.createHybridObject('SalveDatabase'); return true; })()");
+}
+
+int sqlCount(const std::string& sql) {
+  auto rows = DatabaseManager::shared().connection()->execute(sql, {});
+  return static_cast<int>(std::get<double>(rows.rows[0][0]));
+}
+
+std::string configureWithCreds(const std::string& dbName, const std::string& accessToken, const std::string& refreshToken) {
+  return R"(db.configure({
+    name: ')" + dbName + R"(',
+    credentials: {
+      provider: 'oauth2', accessTokenHeaderName: 'Authorization', accessTokenScheme: 'Bearer',
+      tokens: { accessToken: ')" + accessToken + R"(', refreshToken: ')" + refreshToken + R"(' },
+      refresh: { endpoint: '/auth/refresh', responseAccessTokenPath: '$.accessToken', responseRefreshTokenPath: '$.refreshToken' }
+    }
+  }))";
+}
+
+} // namespace
+
+TEST_CASE("db.logout() clears credentials so a later seedInitialTokens isn't silently ignored", "[database][logout][credentials]") {
+  resetSecureStore();
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  harness.run(configureWithCreds(uniqueDbName("logout_creds_a"), "token-a", "refresh-a"));
+  REQUIRE(DatabaseManager::shared().credentials().getAccessToken().value() == "token-a");
+
+  harness.run("db.logout()");
+
+  // Same db name, same connection — configure() again with a different token
+  // pair must actually take, proving the already-seeded guard was cleared.
+  harness.run(configureWithCreds(uniqueDbName("logout_creds_b"), "token-b", "refresh-b"));
+
+  REQUIRE(DatabaseManager::shared().credentials().getAccessToken().value() == "token-b");
+}
+
+TEST_CASE("db.logout() leaves local data rows untouched, unlike reset()", "[database][logout]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("logout_data") + "' })");
+
+  std::string schema = R"({
+    name: "logout_probe", version: 1, primaryKey: "id",
+    columns: { id: { type: "integer" } }
+  })";
+  harness.run("db.registerSchema(JSON.stringify(" + schema + "))");
+  harness.run(R"JS(db.execute("INSERT INTO logout_probe (id) VALUES (?)", [1]))JS");
+  harness.run(R"JS(db.execute("INSERT INTO logout_probe (id) VALUES (?)", [2]))JS");
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM logout_probe") == 2);
+
+  harness.run("db.logout()");
+
+  REQUIRE(sqlCount("SELECT COUNT(*) FROM logout_probe") == 2);
+}
+
+TEST_CASE("db.logout() leaves configure()'d state (network, background) intact, unlike reset()", "[database][logout]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run(R"(db.configure({
+    name: ')" + uniqueDbName("logout_state") + R"(',
+    baseUrl: 'https://api.company.com',
+    network: { timeout: 5000 },
+    background: { minimumInterval: 900000 }
+  }))");
+  REQUIRE(DatabaseManager::shared().appConfigured());
+
+  harness.run("db.logout()");
+
+  REQUIRE(DatabaseManager::shared().isOpen());
+  REQUIRE(DatabaseManager::shared().appConfigured());
+  REQUIRE(DatabaseManager::shared().background().has_value());
+  REQUIRE_NOTHROW(DatabaseManager::shared().network());
+  // Credentials were never configured in this test, so accessing them still throws either way.
+}
+
+TEST_CASE("db.logout() does not throw when no credentials were ever configured", "[database][logout]") {
+  resetSecureStore();
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("logout_no_creds") + "' })");
+
+  REQUIRE_NOTHROW(harness.run("db.logout()"));
+}
+
+TEST_CASE("db.logout() does not throw when the database was never opened", "[database][logout]") {
+  DatabaseManager::shared().closeForTesting();
+  resetSecureStore();
+
+  HybridDatabaseHarness harness;
+  createDb(harness);
+
+  REQUIRE_NOTHROW(harness.run("db.logout()"));
+}
+
+TEST_CASE("db.logout() is serialized against a held sync lock, not run concurrently with it", "[database][logout][concurrency]") {
+  HybridDatabaseHarness harness;
+  createDb(harness);
+  harness.run("db.configure({ name: '" + uniqueDbName("logout_lock") + "' })");
+
+  auto held = DatabaseManager::shared().lockSync();
+
+  std::atomic<bool> logoutDone{false};
+  std::thread t([&]() {
+    harness.run("db.logout()");
+    logoutDone = true;
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  REQUIRE_FALSE(logoutDone.load()); // still waiting on the lock
+
+  held.unlock();
+  t.join();
+  REQUIRE(logoutDone.load());
+}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -61,14 +61,15 @@ function buildDbConfig(tokens: LoginTokens) {
 
 interface AppTabsProps {
   tokens: LoginTokens;
+  onLogout: () => void;
 }
 
-function AppTabs({ tokens }: AppTabsProps): React.JSX.Element {
+function AppTabs({ tokens, onLogout }: AppTabsProps): React.JSX.Element {
   const [tab, setTab] = useState<TabKey>('expenses');
 
   return (
     <View style={styles.flex}>
-      <ResetControls schemas={SCHEMAS} buildConfig={() => buildDbConfig(tokens)} />
+      <ResetControls schemas={SCHEMAS} buildConfig={() => buildDbConfig(tokens)} onLogout={onLogout} />
 
       <View style={styles.flex}>
         {tab === 'expenses' ? <ExpensesScreen /> : null}
@@ -103,7 +104,7 @@ function App(): React.JSX.Element {
   return (
     <SafeAreaProvider>
       <SalveDbProvider config={buildDbConfig(tokens)} schemas={SCHEMAS}>
-        <AppTabs tokens={tokens} />
+        <AppTabs tokens={tokens} onLogout={() => setTokens(null)} />
       </SalveDbProvider>
     </SafeAreaProvider>
   );

--- a/example/src/components/ResetControls.tsx
+++ b/example/src/components/ResetControls.tsx
@@ -12,6 +12,8 @@ type ConfigureProps = Parameters<typeof Database.configure>[0];
 interface ResetControlsProps {
   schemas: AnySchema[];
   buildConfig: () => ConfigureProps;
+  /** Called after a successful `Database.logout()`, so the caller can drop its held tokens and show the login screen again. */
+  onLogout: () => void;
 }
 
 /**
@@ -21,7 +23,7 @@ interface ResetControlsProps {
  * useQuery subscription mounted anywhere in the tab tree) survives instead of
  * silently going stale.
  */
-export function ResetControls({ schemas, buildConfig }: ResetControlsProps): React.JSX.Element {
+export function ResetControls({ schemas, buildConfig, onLogout }: ResetControlsProps): React.JSX.Element {
   const [busy, setBusy] = useState(false);
   const [lastResult, setLastResult] = useState<string | null>(null);
 
@@ -60,6 +62,19 @@ export function ResetControls({ schemas, buildConfig }: ResetControlsProps): Rea
     }
   }
 
+  async function logout() {
+    setBusy(true);
+    setLastResult(null);
+    try {
+      Database.logout();
+      onLogout();
+    } catch (err) {
+      setLastResult(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.buttonRow}>
@@ -68,6 +83,9 @@ export function ResetControls({ schemas, buildConfig }: ResetControlsProps): Rea
         </Pressable>
         <Pressable style={[styles.button, styles.buttonDanger, busy && styles.buttonDisabled]} disabled={busy} onPress={resetAndReconfigure}>
           <Text style={styles.buttonDangerText}>Reset + Reconfigure</Text>
+        </Pressable>
+        <Pressable style={[styles.button, busy && styles.buttonDisabled]} disabled={busy} onPress={logout}>
+          <Text style={styles.buttonText}>Logout</Text>
         </Pressable>
       </View>
       {busy ? <ActivityIndicator color={ACCENT} style={styles.spinner} /> : null}

--- a/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.cpp
@@ -17,6 +17,7 @@ namespace margelo::nitro::salvedb {
       prototype.registerHybridMethod("configure", &HybridSalveDatabaseSpec::configure);
       prototype.registerHybridMethod("registerSchema", &HybridSalveDatabaseSpec::registerSchema);
       prototype.registerHybridMethod("reset", &HybridSalveDatabaseSpec::reset);
+      prototype.registerHybridMethod("logout", &HybridSalveDatabaseSpec::logout);
       prototype.registerHybridMethod("execute", &HybridSalveDatabaseSpec::execute);
       prototype.registerHybridMethod("beginTransaction", &HybridSalveDatabaseSpec::beginTransaction);
       prototype.registerHybridMethod("commit", &HybridSalveDatabaseSpec::commit);

--- a/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridSalveDatabaseSpec.hpp
@@ -66,6 +66,7 @@ namespace margelo::nitro::salvedb {
       virtual void configure(const ConfigureParams& params) = 0;
       virtual std::shared_ptr<Promise<void>> registerSchema(const std::string& schemaJson) = 0;
       virtual std::shared_ptr<Promise<void>> reset() = 0;
+      virtual void logout() = 0;
       virtual QueryResult execute(const std::string& sql, const std::vector<std::variant<nitro::NullType, bool, std::shared_ptr<ArrayBuffer>, std::string, double>>& params) = 0;
       virtual void beginTransaction() = 0;
       virtual void commit() = 0;

--- a/src/database/Database.class.ts
+++ b/src/database/Database.class.ts
@@ -41,6 +41,11 @@ export class Database {
     return this.configureDb.reset()
   }
 
+  /** Clears only the stored credential tokens; local data, schemas, and config are untouched. Use for a normal sign-out. */
+  static logout = () => {
+    return this.configureDb.logout()
+  }
+
   /** Starts a `SELECT` against `schema`'s table. Call `.execute()` on the returned builder to run it. */
   static select = <TSchema extends AnySchema>(schema: TSchema) => {
     return this.queryDb.select(schema);

--- a/src/database/classes/ConfigureDb/ConfigureDb.class.ts
+++ b/src/database/classes/ConfigureDb/ConfigureDb.class.ts
@@ -69,6 +69,11 @@ export class ConfigureDb {
     return this._bridge.reset();
   }
 
+  /** Clears only the stored credential tokens; local data, schemas, and config are untouched. Use for a normal sign-out. */
+  logout(): void {
+    this._bridge.logout();
+  }
+
   static isConfigured(): boolean {
     return ConfigureDb._configured;
   }

--- a/src/database/classes/ConfigureDb/__tests__/ConfigureDb.logout.test.ts
+++ b/src/database/classes/ConfigureDb/__tests__/ConfigureDb.logout.test.ts
@@ -1,0 +1,49 @@
+jest.mock('react-native', () => ({
+  AppState: { currentState: 'active', addEventListener: jest.fn() },
+  Platform: { OS: 'ios' },
+}));
+
+import { ConfigureDb } from '../ConfigureDb.class';
+import type { SalveDatabase } from '../../../../specs/SalveDatabase.nitro';
+
+function makeBridge() {
+  return {
+    configure: jest.fn(),
+    logout: jest.fn(),
+  } as unknown as SalveDatabase;
+}
+
+describe('ConfigureDb.logout()', () => {
+  test('calls bridge.logout()', () => {
+    const bridge = makeBridge();
+
+    new ConfigureDb(bridge).logout();
+
+    expect(bridge.logout).toHaveBeenCalledWith();
+  });
+
+  test('propagates a synchronous bridge throw instead of swallowing it', () => {
+    const bridge = makeBridge();
+    (bridge.logout as jest.Mock).mockImplementation(() => {
+      throw new Error('native keychain error');
+    });
+
+    expect(() => new ConfigureDb(bridge).logout()).toThrow('native keychain error');
+  });
+
+  test('does not require configure() to have run first', () => {
+    const bridge = makeBridge();
+
+    expect(() => new ConfigureDb(bridge).logout()).not.toThrow();
+  });
+
+  test('does not flip ConfigureDb.isConfigured() back to false', () => {
+    const bridge = makeBridge();
+    new ConfigureDb(bridge).configure({ name: 'db' });
+    expect(ConfigureDb.isConfigured()).toBe(true);
+
+    new ConfigureDb(bridge).logout();
+
+    expect(ConfigureDb.isConfigured()).toBe(true);
+  });
+});

--- a/src/specs/SalveDatabase.nitro.ts
+++ b/src/specs/SalveDatabase.nitro.ts
@@ -17,6 +17,15 @@ export interface SalveDatabase extends HybridObject<{ ios: "c++"; android: "c++"
   /** Wipes all local data and credentials in place; `register()` per schema resumes local use, `configure()` again is only needed to restore sync. */
   reset(): Promise<void>;
 
+  /**
+   * Clears only the stored credential tokens (Keychain/Keystore), leaving
+   * local data, schemas, and config untouched. Use for a normal sign-out:
+   * the next `configure()` call with fresh tokens (e.g. after a new login)
+   * seeds them cleanly instead of being silently ignored by the
+   * already-seeded guard.
+   */
+  logout(): void;
+
   // ── Query ──────────────────────────────────────────────────────────────────
 
   /**


### PR DESCRIPTION
## What

New `Database.logout()`: clears only the stored credential tokens (Keychain/Keystore), leaving local data, schemas, and config untouched — a proper sign-out primitive distinct from `reset()` (which wipes everything).

## Why

`reset()` was the only way to clear credentials, but it also wipes all local data — overkill for a normal "log out and let someone else log back in" flow. Tokens never cross the JSI bridge (native-only storage), so a JS-only solution wasn't possible; needed a thin native primitive wrapping the existing `CredentialProvider::clearStoredTokens()`.

## Changes

- `src/specs/SalveDatabase.nitro.ts`: new `logout(): void` in the Nitro spec + regenerated C++ bindings.
- `cpp/HybridSalveDatabase.{hpp,cpp}`: `logout()` calls `CredentialProvider::clearStoredTokens()`, serialized against the same sync lock as `configure()`/`reset()`.
- `src/database/classes/ConfigureDb/ConfigureDb.class.ts` + `src/database/Database.class.ts`: thin JS wrapper, same delegation pattern as every other facade method.
- `example/App.tsx` + `example/src/components/ResetControls.tsx`: new "Logout" button — calls `Database.logout()`, then clears the held tokens so the app returns to `LoginScreen`.

## Tests

- `cpp/tests/HybridSalveDatabaseLogoutTests.cpp` (6 cases, real JSI/Keychain): credentials cleared without silently blocking a later `seedInitialTokens`, local data/config/background untouched (unlike `reset()`), safe no-ops when unconfigured or DB never opened, serialized against a held sync lock.
- `src/database/classes/ConfigureDb/__tests__/ConfigureDb.logout.test.ts` (4 cases): bridge delegation, throw propagation, doesn't require prior `configure()`, doesn't flip `isConfigured()`.
- `npm run test:native`: 839 assertions / 354 cases, all green.
- `npm test`: 196/196 green.
- `tsc --noEmit`: clean (root + `example/`).

## Manual verification (iOS simulator, real build)

Logged in → added an expense → tapped **Logout** → back at `LoginScreen` → logged in again → expense still present (data survives, unlike `Reset`). Server logs confirm two distinct successful logins with no residual 401/keychain errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logout support to securely clear stored login credentials.
  * Logout preserves local data, schemas, and database configuration.
  * Added a Logout button to the example app, returning users to the login screen.
  * Logout is temporarily disabled while processing.

* **Bug Fixes**
  * Added safe handling for logout when no credentials or open database is available.

* **Tests**
  * Added coverage for credential clearing, state preservation, error handling, and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->