### PR TITLE
feat(docs): add Docusaurus documentation site

### DIFF
--- a/website/i18n/pt-BR/code.json
+++ b/website/i18n/pt-BR/code.json
@@ -353,12 +353,6 @@
   "homepage.architecture.title": {
     "message": "O motor de sincronização nunca acorda o runtime JS"
   },
-  "homepage.architecture.lead": {
-    "message": "Um job em segundo plano (WorkManager no Android, BGTaskScheduler no iOS) acorda o orquestrador de sincronização nativo diretamente. Seu app não precisa estar aberto — e nenhuma thread JS chega a subir para isso."
-  },
-  "homepage.architecture.cta": {
-    "message": "Leia o detalhamento completo da arquitetura →"
-  },
   "homepage.cta.title": {
     "message": "Pronto para ir offline-first?"
   },
@@ -445,5 +439,56 @@
   },
   "homepage.features.sectionTitle": {
     "message": "Tudo o que um motor de sincronização em segundo plano deveria ser, sem a bagagem do JS"
+  },
+  "homepage.architecture.subtitle": {
+    "message": "Um job em segundo plano acorda o orquestrador de sincronização nativo diretamente — seu app não precisa estar aberto, e nenhuma thread JS chega a subir para isso."
+  },
+  "homepage.architecture.node.ts": {
+    "message": "TypeScript (camada de DX)"
+  },
+  "homepage.architecture.arrow.jsi": {
+    "message": "JSI (Nitro Modules) — eventos de mudança fluem de volta"
+  },
+  "homepage.architecture.node.core": {
+    "message": "Núcleo Nativo (C++)"
+  },
+  "homepage.architecture.core.sqlite": {
+    "message": "SQLite + cache LRU de prepared statements"
+  },
+  "homepage.architecture.core.migration": {
+    "message": "Migration Engine (ADD COLUMN)"
+  },
+  "homepage.architecture.core.trigger": {
+    "message": "Trigger Engine → sync_queue"
+  },
+  "homepage.architecture.core.orchestrator": {
+    "message": "Sync Orchestrator"
+  },
+  "homepage.architecture.core.credentials": {
+    "message": "Credential Provider (OAuth2)"
+  },
+  "homepage.architecture.core.http": {
+    "message": "Cliente HTTP"
+  },
+  "homepage.architecture.arrow.platform": {
+    "message": "contratos de função platform::"
+  },
+  "homepage.architecture.node.shims": {
+    "message": "Camadas Swift (iOS) / Kotlin (Android)"
+  },
+  "homepage.architecture.shims.background": {
+    "message": "BGTaskScheduler / WorkManager — agendador em segundo plano"
+  },
+  "homepage.architecture.shims.network": {
+    "message": "NWPathMonitor / ConnectivityManager — monitor de rede"
+  },
+  "homepage.architecture.shims.keychain": {
+    "message": "Keychain / Keystore — armazenamento seguro de tokens"
+  },
+  "homepage.architecture.node.api": {
+    "message": "Sua API REST"
+  },
+  "homepage.architecture.readMore": {
+    "message": "Leia o detalhamento completo da arquitetura →"
   }
 }

--- a/website/src/components/HomepageArchitecture/index.tsx
+++ b/website/src/components/HomepageArchitecture/index.tsx
@@ -2,58 +2,123 @@ import type {ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import Heading from '@theme/Heading';
-import CodeBlock from '@theme/CodeBlock';
 import styles from './styles.module.css';
-
-const DIAGRAM = `┌─────────────────────────────┐        JSI (Nitro Modules)        ┌──────────────────────────────┐
-│   TypeScript (DX layer)      │ ─────────────────────────────────▶ │      Native Core (C++)        │
-│                               │                                    │                                │
-│  Database.configure/register │                                    │  SQLite + LRU statement cache  │
-│  Query Builder                │ ◀───────────────────────────────── │  Migration Engine (ADD COLUMN) │
-│  useQuery / useInfiniteQuery │        reactive change events      │  Trigger Engine → sync_queue   │
-│  <SalveDbProvider>            │                                    │  Sync Orchestrator             │
-└─────────────────────────────┘                                    │  Credential Provider (OAuth2)  │
-                                                                      │  HTTP Client                   │
-                                                                      └───────────────┬────────────────┘
-                                                                                       │
-                                                        ┌──────────────────────────────┴──────────────────────────────┐
-                                                        │           Swift (iOS) / Kotlin (Android) shims                │
-                                                        │  BGTaskScheduler / WorkManager — background scheduler         │
-                                                        │  NWPathMonitor / ConnectivityManager — network monitor        │
-                                                        │  Keychain / Keystore — secure token storage                   │
-                                                        └──────────────────────────────┬──────────────────────────────┘
-                                                                                       ▼
-                                                                               Your REST API`;
+import sharedStyles from '../../pages/index.module.css';
 
 export default function HomepageArchitecture(): ReactNode {
   return (
-    <section className={styles.section}>
+    <section className={`${sharedStyles.section} ${sharedStyles.sectionAlt}`}>
       <div className="container">
-        <div className={styles.header}>
-          <p className={styles.eyebrow}>
-            <Translate id="homepage.architecture.eyebrow">
-              Under the hood
-            </Translate>
-          </p>
-          <Heading as="h2">
+        <div className={sharedStyles.sectionHeader}>
+          <span className={sharedStyles.sectionEyebrow}>
+            <Translate id="homepage.architecture.eyebrow">Under the hood</Translate>
+          </span>
+          <Heading as="h2" className={sharedStyles.sectionTitle}>
             <Translate id="homepage.architecture.title">
               The sync engine never wakes the JS runtime
             </Translate>
           </Heading>
-          <p className={styles.lead}>
-            <Translate id="homepage.architecture.lead">
-              A background job (WorkManager on Android, BGTaskScheduler on
-              iOS) wakes the native sync orchestrator directly. Your app
-              doesn't need to be open — and no JS thread ever spins up for it.
+          <p className={sharedStyles.sectionSubtitle}>
+            <Translate id="homepage.architecture.subtitle">
+              A background job wakes the native sync orchestrator directly —
+              your app doesn't need to be open, and no JS thread ever spins
+              up for it.
             </Translate>
           </p>
         </div>
-        <CodeBlock language="text" className={styles.diagram}>
-          {DIAGRAM}
-        </CodeBlock>
-        <div className={styles.ctaRow}>
-          <Link className="button button--outline button--primary" to="/docs/architecture">
-            <Translate id="homepage.architecture.cta">
+
+        <div className={styles.diagram}>
+          <div className={`${styles.node} ${styles.nodeTop}`}>
+            <Translate id="homepage.architecture.node.ts">
+              TypeScript (DX layer)
+            </Translate>
+          </div>
+
+          <div className={styles.arrow}>
+            <span className={styles.arrowLabel}>
+              <Translate id="homepage.architecture.arrow.jsi">
+                JSI (Nitro Modules) — reactive change events flow back
+              </Translate>
+            </span>
+          </div>
+
+          <div className={`${styles.node} ${styles.nodeMid}`}>
+            <Translate id="homepage.architecture.node.core">
+              Native Core (C++)
+            </Translate>
+          </div>
+          <ul className={styles.leafList}>
+            <li>
+              <Translate id="homepage.architecture.core.sqlite">
+                SQLite + LRU statement cache
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.core.migration">
+                Migration Engine (ADD COLUMN)
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.core.trigger">
+                Trigger Engine → sync_queue
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.core.orchestrator">
+                Sync Orchestrator
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.core.credentials">
+                Credential Provider (OAuth2)
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.core.http">HTTP Client</Translate>
+            </li>
+          </ul>
+
+          <div className={styles.arrow}>
+            <span className={styles.arrowLabel}>
+              <Translate id="homepage.architecture.arrow.platform">
+                platform:: function contracts
+              </Translate>
+            </span>
+          </div>
+
+          <div className={`${styles.node} ${styles.nodeLeaf}`}>
+            <Translate id="homepage.architecture.node.shims">
+              Swift (iOS) / Kotlin (Android) shims
+            </Translate>
+          </div>
+          <ul className={styles.leafList}>
+            <li>
+              <Translate id="homepage.architecture.shims.background">
+                BGTaskScheduler / WorkManager — background scheduler
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.shims.network">
+                NWPathMonitor / ConnectivityManager — network monitor
+              </Translate>
+            </li>
+            <li>
+              <Translate id="homepage.architecture.shims.keychain">
+                Keychain / Keystore — secure token storage
+              </Translate>
+            </li>
+          </ul>
+
+          <div className={styles.arrow} />
+
+          <div className={`${styles.node} ${styles.nodeBottom}`}>
+            <Translate id="homepage.architecture.node.api">Your REST API</Translate>
+          </div>
+        </div>
+
+        <div className={styles.readMore}>
+          <Link to="/docs/architecture">
+            <Translate id="homepage.architecture.readMore">
               Read the full architecture breakdown →
             </Translate>
           </Link>

--- a/website/src/components/HomepageArchitecture/styles.module.css
+++ b/website/src/components/HomepageArchitecture/styles.module.css
@@ -1,39 +1,113 @@
-.section {
-  padding: 4rem 0;
-  background: var(--ifm-color-emphasis-100);
-}
-
-[data-theme='dark'] .section {
-  background: #000000;
-}
-
-.header {
-  max-width: 42rem;
-  margin: 0 auto 2rem;
-  text-align: center;
-}
-
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: var(--ifm-color-primary);
-  margin-bottom: 0.5rem;
-}
-
-.lead {
-  color: var(--ifm-color-emphasis-700);
-}
-
 .diagram {
-  max-width: 100%;
-  overflow-x: auto;
-  font-size: 0.7rem;
+  max-width: 34rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.ctaRow {
+.node {
+  padding: 0.9rem 1.5rem;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-align: center;
+  width: 100%;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+}
+
+.nodeTop,
+.nodeBottom {
+  color: var(--ifm-font-color-base);
+}
+
+.nodeMid {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 4px rgba(0, 175, 79, 0.1);
+}
+
+.nodeLeaf {
+  border-color: var(--brand-blue);
+  color: var(--brand-blue);
+}
+
+[data-theme='dark'] .nodeLeaf {
+  color: #6ea8ff;
+  border-color: #6ea8ff;
+}
+
+.nodeBottom {
+  border-color: var(--brand-yellow-dark);
+  color: var(--brand-yellow-dark);
+}
+
+[data-theme='dark'] .nodeBottom {
+  color: var(--brand-yellow);
+  border-color: var(--brand-yellow);
+}
+
+.arrow {
+  position: relative;
+  height: 2.5rem;
+  width: 2px;
+  background: var(--ifm-color-emphasis-300);
+  margin: 0.25rem 0;
+}
+
+.arrow::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid var(--ifm-color-emphasis-300);
+}
+
+.arrowLabel {
+  position: absolute;
+  left: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+}
+
+@media screen and (max-width: 640px) {
+  .arrowLabel {
+    left: 50%;
+    transform: translate(-50%, -50%);
+    white-space: normal;
+    text-align: center;
+    max-width: 12rem;
+    background: var(--ifm-background-color);
+    padding: 0 0.4rem;
+  }
+}
+
+.leafList {
+  list-style: none;
+  padding: 1rem 1.25rem;
+  margin: 0.75rem 0 0;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  width: 100%;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
   display: flex;
-  justify-content: center;
-  margin-top: 2rem;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.readMore {
+  text-align: center;
+  margin-top: 2.5rem;
+  font-weight: 600;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -57,22 +57,6 @@
   border-radius: 6px;
 }
 
-/* Brand stripe divider — echoes the tricolor bar under the Salve DB mark. */
-.brandStripe {
-  display: block;
-  height: 4px;
-  width: 100%;
-  background: linear-gradient(
-    to right,
-    var(--ifm-color-primary) 0%,
-    var(--ifm-color-primary) 33.33%,
-    var(--brand-yellow) 33.33%,
-    var(--brand-yellow) 66.66%,
-    var(--brand-blue) 66.66%,
-    var(--brand-blue) 100%
-  );
-}
-
 .markdown h1:first-child {
   --ifm-h1-font-size: 2.25rem;
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -12,6 +12,23 @@
   color: #ffffff;
 }
 
+.heroStripe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(
+    to right,
+    var(--ifm-color-primary) 0%,
+    var(--ifm-color-primary) 33.33%,
+    var(--brand-yellow) 33.33%,
+    var(--brand-yellow) 66.66%,
+    var(--brand-blue) 66.66%,
+    var(--brand-blue) 100%
+  );
+}
+
 .heroInner {
   max-width: 56rem;
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -75,3 +75,42 @@
     padding: 3rem 1.5rem;
   }
 }
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.sectionAlt {
+  background: var(--ifm-color-emphasis-100);
+}
+
+[data-theme='dark'] .sectionAlt {
+  background: #000000;
+}
+
+.sectionHeader {
+  text-align: center;
+  max-width: 42rem;
+  margin: 0 auto 3rem;
+}
+
+.sectionEyebrow {
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.6rem;
+  display: block;
+}
+
+.sectionTitle {
+  font-size: 2.1rem;
+  font-weight: 800;
+}
+
+.sectionSubtitle {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1.05rem;
+  margin-top: 0.75rem;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -25,7 +25,7 @@ Database.insert(UserSchema)
 function HomepageHeader() {
   return (
     <header className={styles.heroBanner}>
-      <span className="brandStripe" />
+      <span className={styles.heroStripe} />
       <div className={`container ${styles.heroInner}`}>
         <p className={styles.eyebrow}>
           <Translate id="homepage.hero.badge">


### PR DESCRIPTION
## What

`main` doesn't have the docs site yet — this PR carries the full `website/` addition already merged into `develop` via #123, plus two homepage visual fixes on top:

- **feat(docs): add Docusaurus documentation site** (#123, already reviewed/merged into `develop`) — full site under `website/`, 19 doc pages (EN + pt-BR), GitHub Pages deploy workflow, README link.
- **fix(docs): align hero brand stripe with navbar** — the tricolor stripe was flowing in normal document flow instead of sitting flush against the navbar like on `react-native-nitro-jsdom`; now absolutely positioned.
- **refactor(docs): replace architecture diagram with visual node chart** — the "Under the hood" homepage section was a plain ASCII-art text block; replaced with a color-coded node/arrow diagram matching jsdom's visual pattern (green core, blue platform shims, yellow external API), with labeled arrows and responsibility lists.

## Verification

- `npm run build` clean for both `en`/`pt-BR` locales, no broken links/anchors.
- Visually reviewed via browser screenshots (dev server + static build) for both locales — hero stripe now flush against navbar, architecture diagram renders correctly in EN and pt-BR.

## Follow-up

GitHub Pages is already configured (`build_type: workflow`, homepage field set to `https://salve-software.github.io/react-native-salve-db/`). The deploy workflow triggers on push to `website/**` on `main` — merging this PR will trigger the first deploy.

🤖 Generated with a Claude Haiku 4.5 agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the homepage architecture section with a structured visual diagram showing application, native, platform, and API layers.
  * Added explanatory labels, component details, and a read-more link in Portuguese (Brazilian).
  * Added reusable styling for homepage sections, headings, subtitles, and diagram elements.
  * Updated the hero banner with a branded gradient stripe.

* **Style**
  * Removed the previous architecture text-based diagram and replaced it with a responsive visual layout.
  * Removed the former global branding stripe styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->